### PR TITLE
Fixed Signature of ATmega 3209 and 3208.

### DIFF
--- a/avrdude.conf
+++ b/avrdude.conf
@@ -16048,7 +16048,7 @@ part parent    ".avr8x_tiny"
 part parent    ".avr8x_mega"
     id        = "m3208";
     desc      = "ATmega3208";
-    signature = 0x1E 0x95 0x52;
+    signature = 0x1E 0x95 0x30;
 
     memory "flash"
         size      = 0x8000;
@@ -16072,7 +16072,7 @@ part parent    ".avr8x_mega"
 part parent    ".avr8x_mega"
     id        = "m3209";
     desc      = "ATmega3209";
-    signature = 0x1E 0x95 0x53;
+    signature = 0x1E 0x95 0x31;
 
     memory "flash"
         size      = 0x8000;


### PR DESCRIPTION
Signatures of ATmega 3209 and 3208 seemed to be wrong.
I checked the operation of ATmega 3209.