### PR TITLE
Add AVR JTAG ICE v2.0 usb stick support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ avrdude done.  Thank you.
 </pre>
 
 
+## Using with AVR JTAG ICE usb stick
+
+The code can be used with the compact **AVR JTAG ICE** usb stick available to buy online from various sources.
+
+See [Tools](tools/avrjtagicev2) section of the project on how to prepare and use the stick.
+
+
 ## Troubleshooting
 
 If you have triple-checked all the connections but still getting errors, the problem might be the speed of the serial links. I have set the jtag2updi entry on the avrdude configuration file to run at 115200 baud by default. This baud rate can cause errors, for example, if your MCU is running at 8MHz.

--- a/make.bat
+++ b/make.bat
@@ -22,12 +22,20 @@ rem Optional optimization settings
 rem Otherwise unused r/w I/O registers residing in I/O addresses 0-63 can be used here
 set DEFINES=%DEFINES% -DTEMP0=GPIOR0 -DTEMP1=GPIOR1 -DTEMP2=GPIOR2
 
+rem 
+rem select AVRJTAGICE v2.0 as target (override upper)
+rem 
+rem set TARGETMCU=atmega16
+rem set DEFINES=-DNDEBUG -DUPDI_BAUD=120000U -DF_CPU=7372800 -DLED_PORT=B -DLED_PIN=3 -DUPDI_PORT=D -DUPDI_PIN=2
+
+
 echo Compiling for %TARGETMCU%...
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o UPDI_lo_lvl.o %SOURCEPATH%/UPDI_lo_lvl.cpp
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o UPDI_hi_lvl.o %SOURCEPATH%/UPDI_hi_lvl.cpp
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o jtag2updi.o %SOURCEPATH%/jtag2updi.cpp
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o jice_io.o %SOURCEPATH%/jice_io.cpp
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o JTAG2.o %SOURCEPATH%/JTAG2.cpp
+%BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o updi_io_soft.o %SOURCEPATH%/updi_io_soft.cpp
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o updi_io.o %SOURCEPATH%/updi_io.cpp
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o crc16.o %SOURCEPATH%/crc16.cpp
 %BINPATH%\avr-g++.exe %DEFINES% -c -I%INCPATH% %OPTFLAGS% %CSTDFLAGS% -Wall -mmcu=%TARGETMCU% -o sys.o %SOURCEPATH%/sys.cpp
@@ -35,7 +43,7 @@ echo Compiling for %TARGETMCU%...
 echo Linking...
 mkdir %BUILDPATH%
 set OPTFLAGS=-Os -flto -mrelax
-%BINPATH%\avr-g++.exe -o %BUILDPATH%\JTAG2UPDI.elf jtag2updi.o JTAG2.o jice_io.o UPDI_lo_lvl.o UPDI_hi_lvl.o updi_io.o crc16.o sys.o -Wl,-Map="%BUILDPATH%\STK2UPDI.map" -Wl,--start-group -Wl,-lm -Wl,--end-group -Wl,--gc-sections -mmcu=%TARGETMCU% %OPTFLAGS%
+%BINPATH%\avr-g++.exe -o %BUILDPATH%\JTAG2UPDI.elf jtag2updi.o JTAG2.o jice_io.o UPDI_lo_lvl.o UPDI_hi_lvl.o updi_io.o updi_io_soft.o crc16.o sys.o -Wl,-Map="%BUILDPATH%\STK2UPDI.map" -Wl,--start-group -Wl,-lm -Wl,--end-group -Wl,--gc-sections -mmcu=%TARGETMCU% %OPTFLAGS%
 
 echo Cleaning up...
 del *.o

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# avr-gcc++ path
+BINPATH="/usr/bin"
+INCPATH="./source"
+
+SOURCEPATH="$PWD/source/"
+BUILDPATH="$PWD/build"
+
+OPTFLAGS="-Os -fno-jump-tables -fno-gcse -flto -ffunction-sections -fdata-sections -fpack-struct -fshort-enums -mrelax"
+CSTDFLAGS="-funsigned-char -funsigned-bitfields -std=gnu++14"
+
+# select atmega168 or atmega328p as target
+TARGETMCU=atmega328p
+
+# configuration macros
+# NDEBUG -> disable debug output
+# F_CPU=value -> declares at which speed the CPU is running (defaults to 16000000, 16MHz)
+# UPDI_BAUD=value -> sets UPDI baud rate. Maxumum is 225000 (225 kbaud, default value). Minimum is F_CPU/100
+DEFINES="-DNDEBUG -DUPDI_BAUD=225000U -DF_CPU=16000000" #atmega328
+
+# Optional optimization settings
+# Otherwise unused r/w I/O registers residing in I/O addresses 0-63 can be used here
+DEFINES="$DEFINES -DTEMP0=GPIOR0 -DTEMP1=GPIOR1 -DTEMP2=GPIOR2"
+
+##
+## select AVRJTAGICE v2.0 as target (override upper)
+##
+#TARGETMCU=atmega16
+#DEFINES="-DNDEBUG -DUPDI_BAUD=120000U -DF_CPU=7372800 -DLED_PORT=B -DLED_PIN=3 -DUPDI_PORT=D -DUPDI_PIN=2"
+
+echo Compiling for $TARGETMCU ...
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o UPDI_lo_lvl.o $SOURCEPATH/UPDI_lo_lvl.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o UPDI_hi_lvl.o $SOURCEPATH/UPDI_hi_lvl.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o jtag2updi.o $SOURCEPATH/jtag2updi.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o JICE_io.o $SOURCEPATH/JICE_io.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o JTAG2.o $SOURCEPATH/JTAG2.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o updi_io_soft.o $SOURCEPATH/updi_io_soft.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o updi_io.o $SOURCEPATH/updi_io.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o crc16.o $SOURCEPATH/crc16.cpp
+$BINPATH/avr-g++ $DEFINES -c -I$INCPATH $OPTFLAGS $CSTDFLAGS -Wall -mmcu=$TARGETMCU -o sys.o $SOURCEPATH/sys.cpp
+
+echo Linking...
+if [ ! -d $BUILDPATH ]
+then
+  mkdir $BUILDPATH
+fi
+set OPTFLAGS="-Os -flto -mrelax"
+$BINPATH/avr-g++ -o $BUILDPATH/JTAG2UPDI.elf \
+                    jtag2updi.o JTAG2.o JICE_io.o UPDI_lo_lvl.o \
+                    UPDI_hi_lvl.o updi_io.o updi_io_soft.o crc16.o sys.o \
+                 -Wl,-Map="$BUILDPATH/STK2UPDI.map" -Wl,-lm \
+                 -Wl,--start-group -Wl,--end-group -Wl,--gc-sections \
+                 -mmcu=$TARGETMCU $OPTFLAGS
+
+echo Cleaning up...
+rm -rf *.o
+
+cd $BUILDPATH
+
+echo Creating HEX file...
+$BINPATH/avr-objcopy -O ihex "JTAG2UPDI.elf" "JTAG2UPDI.hex"
+
+echo Creating LSS file...
+$BINPATH/avr-objdump -h -S "JTAG2UPDI.elf" > "JTAG2UPDI.lss"

--- a/source/JICE_io.cpp
+++ b/source/JICE_io.cpp
@@ -18,16 +18,37 @@ namespace {
 
 // Functions
 uint8_t JICE_io::put(char c) {
+#ifdef __AVR_ATmega16__
+	loop_until_bit_is_set(UCSRA, UDRE);
+	return UDR = c;
+#else
 	loop_until_bit_is_set(UCSR0A, UDRE0);
 	return UDR0 = c;
+#endif
 }
 
 uint8_t JICE_io::get(void) {
+#ifdef __AVR_ATmega16__
+	loop_until_bit_is_set(UCSRA, RXC); /* Wait until data exists. */
+	return UDR;
+#else
 	loop_until_bit_is_set(UCSR0A, RXC0); /* Wait until data exists. */
 	return UDR0;
+#endif
 }
 
 void JICE_io::init(void) {
+#ifdef __AVR_ATmega16__
+	/* Set double speed */
+	UCSRA = (1<<U2X);
+	/* Set initial baud rate */
+	UBRRH = 0;
+	UBRRL = baud(19200);
+	/* Enable receiver and transmitter */
+	UCSRB = (1<<RXEN)|(1<<TXEN);
+	/* Set frame format: 8data, 1stop bit */
+	UCSRC = (1<<URSEL)|(1<<UCSZ0)|(1<<UCSZ1);
+#else
 	/* Set double speed */
 	UCSR0A = (1<<U2X0);
 	/* Set initial baud rate */
@@ -36,13 +57,24 @@ void JICE_io::init(void) {
 	UCSR0B = (1<<RXEN0)|(1<<TXEN0);
 	/* Set frame format: 8data, 1stop bit */
 	UCSR0C = (1<<UCSZ00)|(1<<UCSZ01);
+#endif
 }
 
 void JICE_io::flush(void) {
+#ifdef __AVR_ATmega16__
+	UCSRA |= 1 << TXC;
+	loop_until_bit_is_set(UCSRA, TXC);
+#else
 	UCSR0A |= 1 << TXC0;
 	loop_until_bit_is_set(UCSR0A, TXC0);
+#endif
 }
 
 void JICE_io::set_baud(JTAG2::baud_rate rate) {
+#ifdef __AVR_ATmega16__
+	UBRRH = 0;
+	UBRRL = baud_tbl[rate - 1];
+#else
 	UBRR0 = baud_tbl[rate - 1];
+#endif
 }

--- a/source/sys.cpp
+++ b/source/sys.cpp
@@ -6,12 +6,21 @@
  */ 
 
 #include <avr/io.h>
+#include <avr/interrupt.h>
+
 #include "sys.h"
 
+#ifndef LED_PORT
 #define LED_PORT B
+#endif
+#ifndef LED_PIN
 #define LED_PIN 5
+#endif
 
 void SYS::init(void) {
+
+#ifndef __AVR_ATmega16__
+
 	/* Disable digital input buffers on port C */
 	DIDR0 = 0x3F;
 	/* Enable all port D pull-ups */
@@ -26,6 +35,34 @@ void SYS::init(void) {
 		(1 << PRTIM1) |		// turn off timer 1
 		(1 << PRSPI) |		// turn off SPI interface
 		(1 << PRADC);		// turn off the ADC
+
+#else
+
+        /* No interrupts */
+        sei();
+        /* Enable all port D pull-ups */
+        PORT(UPDI_PORT) = 0xFF;
+        /* Enable LED */
+        PORT(LED_PORT) |= (1 << LED_PIN);
+        /* Enable all port B pull-ups, except for LED */
+        PORT(LED_PORT) = 0xFF - (1 << LED_PIN);
+
+        /* Disable unused peripherals */
+        SPCR &= ~(1<<SPE);
+        ADC  &= ~(1<<ADEN);
+        TWCR &= ~(1<<TWEN);
+
+        /* Disable resources after bootloader */
+        TIFR   = 0x00;
+        TIMSK  = 0x00;
+        TCNT1  = 0x0000;
+        OCR1A  = 0x0000;
+        OCR1B  = 0x0000;
+        TCCR1A = 0x0000;
+        TCCR1B = 0x0000;
+
+#endif
+
 }
 
 void SYS::setLED(void){

--- a/source/updi_io.cpp
+++ b/source/updi_io.cpp
@@ -5,6 +5,9 @@
  *  Author: JMR_2
  */ 
 
+
+#ifndef __AVR_ATmega16__
+
 // Includes
 #include <avr/io.h>
 #include "updi_io.h"
@@ -221,3 +224,5 @@ namespace {
 	}
 }
 
+
+#endif //__AVR_ATmega16__

--- a/source/updi_io_soft.cpp
+++ b/source/updi_io_soft.cpp
@@ -1,0 +1,250 @@
+/*
+ * updi_io_soft.cpp
+ *
+ * Created: 11-08-2018 22:08:14
+ *  Author: Cristian Balint <cristian dot balint at gmail dot com>
+ */
+
+#ifdef __AVR_ATmega16__
+
+// Includes
+#include <avr/io.h>
+#include <util/delay.h>
+
+#include "sys.h"
+#include "updi_io.h"
+
+// Defines
+#ifndef F_CPU
+#  define F_CPU 16000000U
+#endif
+#ifndef UPDI_BAUD
+#  define UPDI_BAUD 225000U  // (max 225000 min approx. F_CPU/100)
+#endif
+
+// Cycle timing
+#define TXDELAY (uint8_t)(((F_CPU/UPDI_BAUD) - 9) / 3)
+#define RXDELAY (uint8_t)(((F_CPU/UPDI_BAUD) - 9) / 3)
+#define RXHALFD (uint8_t)  (RXDELAY / 2)
+
+// Check
+#if ( (((F_CPU/UPDI_BAUD) - 9) / 3) > 254 )
+# error Low baud rates are not supported - use higher UPDI_BAUD
+#endif
+
+// Functions
+/* Sends regular characters through the UPDI link */
+uint8_t UPDI_io::get() {
+
+        // rx input
+        DDR(UPDI_PORT)  &= ~(1 << UPDI_PIN);
+        // no pullup
+        PORT(UPDI_PORT) &= ~(1 << UPDI_PIN);
+
+        uint8_t c;
+
+        __asm volatile
+        (
+            " ldi  %0, 0 \n\t"           // init
+            " ldi r20, 8 \n\t"           // 8 bits
+            " ldi r19, 3 \n\t"           // 1 parity + 2 stop bits
+
+            // wait for start edge
+            "WaitStart: \n\t"
+            " sbic %[uart_port], %[uart_pin] \n\t"
+            " rjmp WaitStart \n\t"
+
+            // skew into middle of edge
+            " ldi r18, %[rxhalfd] \n\t"  // 0.5 bit cycle delay
+            "HBitDelay: \n\t"
+            " dec r18 \n\t"
+            " brne HBitDelay \n\t"
+
+            // 8 bits
+            "RxBLoop: \n\t"
+            " ldi r18, %[rxdelay] \n\t"  // 1 bit cycle delay
+            "RxBDelay: \n\t"
+            " dec r18 \n\t"
+            " brne RxBDelay \n\t"
+            " in r21, %[uart_port] \n\t" // get current bit from serial link
+            " bst r21, %[uart_pin] \n\t" // use T flag
+            " bld r22, 0\n\t"            // to move current data bit
+            " lsr r22 \n\t"              // into carry
+            " ror %0 \n\t"               // accumulate serial data bits into result
+            " dec r20 \n\t"
+            " brne RxBLoop \n\t"
+            " nop \n\t"
+
+            // 1 parity + 2 stop bits
+            "RxSLoop: \n\t"
+            " ldi r18, %[rxdelay] \n\t"  // 1 bit cycle delay
+            "RxSDelay: \n\t"
+            " dec r18 \n\t"
+            " brne RxSDelay \n\t"
+            " in r21, %[uart_port] \n\t" // get current bit from serial link
+            " bst r21, %[uart_pin] \n\t" // use T flag
+            " bld r22, 0\n\t"            // to move current data bit
+            " lsr r22 \n\t"              // into carry
+            " nop \n\t"                  // accumulate serial data bits into result
+            " dec r19 \n\t"
+            " brne RxSLoop \n\t"
+            " nop \n\t"
+
+            : "=r" (c)
+            : [uart_port] "i" (_SFR_IO_ADDR(PIN(UPDI_PORT))),
+              [uart_pin]  "i" (UPDI_PIN),
+              [rxdelay]   "i" (RXDELAY),
+              [rxhalfd]   "i" (RXHALFD)
+            : "r0","r18","r19","r20","r21","r22"
+        );
+
+        // re-enable pull up
+        PORT(UPDI_PORT) |= (1 << UPDI_PIN);
+
+        return c;
+}
+
+uint8_t UPDI_io::put(char c) {
+
+        // tx enable
+        DDR(UPDI_PORT) |= (1 << UPDI_PIN);
+
+        __asm volatile
+        (
+            " in r0, %[uart_port] \n\t"  // port state
+            " ldi r26, 2 \n\t"           // 2 bit stop
+            " ldi r27, 8 \n\t"           // 8 bit parity
+            " ldi r28, %[txdelay] \n\t"  // delay counter
+            " ldi r30, 8 \n\t"           // 8 bit loop
+
+            // pre delay
+            // 2 bit time
+            " mov r29, r28 \n\t"
+            "TxDelay: \n\t"
+            " nop \n\t"
+            " dec r29 \n\t"
+            " brne TxDelay \n\t"
+
+            // start bit
+            " mov r29, r28 \n\t"
+            "TxDelayS: \n\t"
+            " dec r29 \n\t"
+            " brne TxDelayS \n\t"
+            " bclr 6 \n\t"
+            " bld r0, %[uart_pin] \n\t"
+            " nop \n\t"
+            " nop \n\t"
+            " nop \n\t"
+            " out %[uart_port], r0 \n\t"
+            " nop \n\t"
+            " nop \n\t"
+
+            // 8 bits
+            "TxLoop: \n\t"
+            " mov r29, r28 \n\t"         // load delay counter
+            "TxDelayB: \n\t"             // delay (3 cycle * delayCount) - 1
+            " dec r29 \n\t"
+            " brne TxDelayB \n\t"
+            " bst %[ch], 0 \n\t"         // load bit in T
+            " bld r0, %[uart_pin] \n\t"  // store T bit in r0
+            " ror %[ch] \n\t"            // shift right into carry
+            " sbci r27, 0 \n\t"          // subtract carry (accumulate parity)
+            " dec r30 \n\t"              // decrement bits counter
+            " out %[uart_port], r0 \n\t" // send bit out
+            " brne TxLoop \n\t"          // loop for each bit
+            " nop \n\t"
+
+            // parity bit
+            " mov r29, r28 \n\t"
+            "TxDelayP: \n\t"
+            " dec r29 \n\t"
+            " brne TxDelayP \n\t"
+            " bst r27, 0 \n\t"           // extract accumulated parity
+            " bld r0, %[uart_pin] \n\t"
+            " nop \n\t"
+            " nop \n\t"
+            " nop \n\t"
+            " out %[uart_port], r0 \n\t" // send bit out to serial link
+            " nop \n\t"
+            " nop \n\t"
+
+            // stop bits
+            "StopLoop: \n\t"
+            " mov r29, r28 \n\t"
+            "TxDelayStop: \n\t"
+            " dec r29 \n\t"
+            " brne TxDelayStop \n\t"
+            " bset 6 \n\t"
+            " bld r0, %[uart_pin] \n\t"
+            " nop \n\t"
+            " nop \n\t"
+            " dec r26 \n\t"
+            " out %[uart_port], r0 \n\t" // send bit out to serial link
+            " brne StopLoop \n\t"        // loop for each bit
+            " nop \n\t"
+
+            :
+            : [uart_port] "i" (_SFR_IO_ADDR(PORT(UPDI_PORT))),
+              [uart_pin]  "i" (UPDI_PIN),
+              [txdelay]   "i" (TXDELAY),
+              [ch]        "r" (c)
+            : "r0","r26","r27","r28","r29","r30"
+        );
+
+        // Ready for RX input
+        DDR(UPDI_PORT) &= ~(1 << UPDI_PIN);
+
+        return c;
+}
+
+static inline void send_break() {
+
+        // tx enable
+        DDR(UPDI_PORT) |= (1 << UPDI_PIN);
+
+        //
+        // 13 cycles = 24.60ms
+        //
+
+        // low 12 cycle
+        PORT(UPDI_PORT) &= ~(1 << UPDI_PIN);
+        _delay_us(2048*11);
+
+        // high 1 cycle
+        PORT(UPDI_PORT) |=  (1 << UPDI_PIN);
+        _delay_us(2048);
+
+        // RX enable
+        DDR(UPDI_PORT) &= ~(1 << UPDI_PIN);
+
+        return;
+}
+
+/* Sends special sequences through the UPDI link */
+uint8_t UPDI_io::put(ctrl c) {
+
+        switch (c) {
+
+          case double_break:
+              send_break();
+              send_break();
+              break;
+
+          case single_break:
+              send_break();
+              break;
+
+          case enable:
+
+          default:
+              break;
+        }
+
+        return 0;
+}
+
+void UPDI_io::init(void) {
+
+}
+
+#endif //__AVR_ATmega16__

--- a/tools/avrjtagicev2/README.md
+++ b/tools/avrjtagicev2/README.md
@@ -1,0 +1,112 @@
+# AVR JTAG ICE v2.0
+
+The firmware can be uploaded to **AVR JTAG ICE** usb stick with no dismantling or soldering just by a simple upload tool.
+
+
+Currently AVR JTAG ICE can be bought from various sources, one of them: [Aliexpress](https://www.aliexpress.com/item/AVR-JTAG-ICE-USB-Download-Programmer-Emulator-Aluminum-Shell-Over-Current-Protection-Wide-Voltage-Buffer-Chip/32656234883.html)
+
+<pre>
+
+
+
+ +----------+          +---------------------+                           +--------------------+
+ | PC       |          | AVR JTAG ICE  VTref +(4)--------->--------------+ Vcc                |
+ | avrdude  |          |                     |      +----------+         |                    |
+ |          |          |               nSRST +(6)---+   4k7    +---------+ UPDI               |
+ |      USB +----------+ USB                 |      +----------+         |                    |
+ |          |          |                     |                           |       Target       |
+ |          |          |                     |                           |                    |
+ |          |          |                     |                           |                    |
+ |          |          |                 GND +(2)-+                   +--+ GND                |
+ +----------+          +---------------------+    |                   |  +--------------------+
+             JTAGICE MkII                        +-+     UPDI        +-+
+             Protocol                            GND     Protocol    GND
+
+</pre>
+
+
+Just remember **VTref** will supply the target MCU chip with **5V** from the AVR JTAG ICE ! For using with different own MCU board potential (e.g. 3.3V or 1.8V) leave **VTref** unconnected. Also you can step down the voltage using a regulator (e.g. 3.3V) from **VTref** if target mcu supports lower voltage only.
+
+## Building the firmware
+
+Uncomment lines below to enable AVR JTAG ICE support and then run makefile to compile the firmware.
+
+* For windows build edit **make.bat** remove remarks from two lines:
+
+```
+...
+rem
+rem select AVRJTAGICE v2.0 as target (override upper)
+rem
+set TARGETMCU=atmega16
+set DEFINES=-DNDEBUG -DUPDI_BAUD=120000U -DF_CPU=7372800 ...
+...
+```
+
+* For linux build edit **make.sh** uncomment two of the lines:
+```
+...
+##
+## select AVRJTAGICE v2.0 as target (override upper)
+##
+TARGETMCU=atmega16
+DEFINES="-DNDEBUG -DUPDI_BAUD=120000U -DF_CPU=7372800 ...
+...
+```
+
+## Flashing the firmware
+
+To burn the USB module, use [avr-aosp.py](https://github.com/cbalint13/avr-aosp/) uploader tool (as superuser) plug in USB module and while the LED blinks fast red-blue (5 seconds window at statup) run these steps:
+
+1) Erase content of module:
+
+```
+python2 avr-aosp.py -op erase
+
+INFO
+
+  S = AVRBOOT 	#programmer id
+  V = 10 	#software version
+  v = ? 	#hardware version
+  p = S 	#programmer type
+  a = Y 	#autoincrement support
+  b = ? 	#block mode support
+  t = [7400] 	#supported device code
+  s = 02941e 	#signature
+  N = ? 	#high fuse bits
+  F = ? 	#low fuse bits
+  r = ? 	#lock bits
+  Q = ? 	#extended fuse bits
+
+ERASE program memory
+
+```
+
+2) Upload the firmware:
+
+```
+python2 avr-aosp.py -op write -file ../../build/JTAG2UPDI.hex
+
+INFO
+
+  S = AVRBOOT 	#programmer id
+  V = 10 	#software version
+  v = ? 	#hardware version
+  p = S 	#programmer type
+  a = Y 	#autoincrement support
+  b = ? 	#block mode support
+  t = [7400] 	#supported device code
+  s = 02941e 	#signature
+  N = ? 	#high fuse bits
+  F = ? 	#low fuse bits
+  r = ? 	#lock bits
+  Q = ? 	#extended fuse bits
+
+WRITE program memory [../../build/JTAG2UPDI.hex] #2378 bytes
+0...10...20...30...40...50...60...70...80...90...100 - done.
+
+```
+
+3) Unplug and then replug the USB stick, red-blue blinking stops with permanent red LED turned on.
+
+4) With red LED turned on firmware is active and can be used with avrdude, see provided wiring to target MCU.


### PR DESCRIPTION
Dear @ElTangas &all,

  This patch adds support for the cheap and elegant [**AVR JTAG ICE**](https://www.aliexpress.com/item/AVR-JTAG-ICE-USB-Download-Programmer-Emulator-Aluminum-Shell-Over-Current-Protection-Wide-Voltage-Buffer-Chip/32656234883.html) usb sticks available on various online stores. Does not require any invasive dismantling or soldering on the stick, firmware can be simply uploaded with the provided python tool.

   I am using this port since few months on such sticks, works perfect, never had any single glitches.

Hope will be useful for the audience.

---

 To be able to add this support, the following was needed:

  - mcu cycle exact soft I/O routines (could help ports on other devices, on any port & pin layout)
  - simple usb flash uploader tool (implements simple AOSP protocol for stick's bootloader)
  - simple documentation on how to burn, use and wire the stick.



