### PR TITLE
Fix ATtiny402 device signatures

### DIFF
--- a/avrdude.conf
+++ b/avrdude.conf
@@ -15372,7 +15372,31 @@ part parent    ".avr8x_tiny"
 part parent    ".avr8x_tiny"
     id        = "t402";
     desc      = "ATtiny402";
-    signature = 0x1E 0x92 0x23;
+    signature = 0x1E 0x92 0x27;
+
+    memory "flash"
+        size      = 0x1000;
+        offset    = 0x8000;
+        page_size = 0x40;
+        readsize  = 0x100;
+    ;
+
+    memory "eeprom"
+        size      = 0x80;
+        offset    = 0x1400;
+        page_size = 0x20;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny402w = workaround to address wrong device signature on some chips
+#------------------------------------------------------------
+
+part parent    ".avr8x_tiny"
+    id        = "t402w";
+    desc      = "ATtiny402w";
+    signature = 0x1E 0x92 0x25;
 
     memory "flash"
         size      = 0x1000;


### PR DESCRIPTION
Also a workaround, with ID "402w" for chips with the wrong signature. Should fix issue #12