### PR TITLE
Support AVR-DA, add debug channel, add timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It provides a bridge to program the new attiny817 family of MCUs, that use the U
 
 avrdude -> HW Serial interface -> Programmer MCU (e.g. Mega328P) -> SW Serial on PD6 -> Target MCU (e.g. tiny817)
 
-Currently, I have not tested this software with a level shifter, however, since the UPDI pin is high voltage tolerant, it's ok to have V_prog > V_target, but not the reverse. <strong>Warning: only the UPDI pins of devices that support high voltage programming should be assumed to be high voltage tolerant. This is not the case for the MegaAVR 0-series or AVR-DA series! </strong>
+Currently, I have not tested this software with a level shifter, however, since the UPDI pin is high voltage tolerant, it's ok to have V_prog > V_target, but not the reverse. <strong>Warning: only the UPDI pins of devices that support high voltage programming should be assumed to be high voltage tolerant. This is not the case for the MegaAVR 0-series or AVR-DA series! </strong> However, the current injection spec for I/O pins on these parts is far more generous that it is for older AVR devices it is not clear if the UPDI pin is included in this.
 
 Notice, however, that the logic levels need to be compatible for successful programming: V_target cannot be lower than about 60% of V_prog (60% will likelly work, 70% is guaranteed to work). Therefore, it will not be possible to program a 2.5V target with a 5.0V programmer, because communication errors will surely occur (but no electrical damage), but if V_target is 3.3V (66% of 5.0V) chances are good.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ It provides a bridge to program the new attiny817 family of MCUs, that use the U
 
 avrdude -> HW Serial interface -> Programmer MCU (e.g. Mega328P) -> SW Serial on PD6 -> Target MCU (e.g. tiny817)
 
-Currently, I have not tested this software with a level shifter, however, since the UPDI pin is high voltage tolerant, it's ok to have V_prog > V_target, but not the reverse. <strong>Warning: only the UPDI pins of devices that support high voltage programming should be assumed to be high voltage tolerant. This is not the case for the Mega AVR-0 series!</strong>
+Currently, I have not tested this software with a level shifter, however, since the UPDI pin is high voltage tolerant, it's ok to have V_prog > V_target, but not the reverse. <strong>Warning: only the UPDI pins of devices that support high voltage programming should be assumed to be high voltage tolerant. This is not the case for the MegaAVR 0-series or AVR-DA series! </strong>
 
 Notice, however, that the logic levels need to be compatible for successful programming: V_target cannot be lower than about 60% of V_prog (60% will likelly work, 70% is guaranteed to work). Therefore, it will not be possible to program a 2.5V target with a 5.0V programmer, because communication errors will surely occur (but no electrical damage), but if V_target is 3.3V (66% of 5.0V) chances are good.
+
 
 <pre>
                                             V_prog                 V_target
@@ -36,7 +37,7 @@ Alternatively, you can use an Arduino without integrated USB/serial adapter, lik
 
 ## Building with avr-gcc
 
-To build, run the make.bat file, after editing it with the following options: 
+To build, run the make.bat file, after editing it with the following options:
 1) path of AVR-GCC on your system
 2) correct target MCU
 3) Frequency at which your MCU is running (F_CPU, defaults to 16MHz)
@@ -121,6 +122,7 @@ avrdude -c jtag2updi -P com7 -p t1614 -e
 </pre>
 
 Alternatively, you can erase the chip from interactive mode, enter it using "-t", and "-F" to override the error:
+Note: You must build with DISABLE_HOST_TIMEOUT defined for terminal mode to work. See below for more information on the timeouts.
 <pre>
 avrdude -c jtag2updi -P com7 -p t1614 -t -F
 </pre>
@@ -149,6 +151,23 @@ avrdude> quit
 avrdude done.  Thank you.
 </pre>
 
+
+## Extra information
+If you call avrdude with -v -v -v -v (maximum verbosity) so you see all the data sent back, it will add
+
+
+## Debug channel
+Regardless of what AVR you are running it on, you can enable SPI debugging in sys.h (see commented out examples) - this outputs data on SPI that is meant to be converted to serial on another board - this debug channel allows you to get something approxiomating a serial port to print debug info to on parts without a second USART
+On parts with multiple USARTS, you can just use that for debugging (similarly, there are commented out examples). Both print the same data.
+In dbg.h, you can enable extended information for most UPDI calls.
+
+## Timeouts
+Previous versions of jtag2updi could get hung up waiting for a target that wasn't working (for example, because it was connected incorrectly) or the host (for example, if you entered a slow command, like reading a 128k flash memory when you didn't intend to, and ctrl-c hoping to "save time"), requiring a reset to reconnect to it. This version has timeouts on communication with both the host (250ms - it gives up and assumes the host isn't going to sat anything after three timeouts, and awaits a fresh session from avrdude), and when talking to the target (100ms - which is far more time than the target should ever take to respond). In the event of a timeout communicating with the target, it will return RSP_NO_TARGET_POWER response. The host timeout of course prevents terminal mode from working (target timeout should just prevent hangs without downside)
+Both can be disabled by uncommenting #define DISABLE_TARGET_TIMEOUT and/or #define DISABLE_HOST_TIMEOUT in sys.h - the latter should uncommented if terminal mode is to be used, and should remain commented out if terminal mode will not be used.
+
+## Supported parts
+jtag2updi was tested on tinyAVR 0-series and 1-series and ATmega 328p/168p.
+It is expected to work on classic megaAVR x8, x4, x1, and x0 parts, as well as megaAVR 0-series and AVR-DA parts.
 
 ## Using with AVR JTAG ICE usb stick
 

--- a/avrdude.conf
+++ b/avrdude.conf
@@ -36,7 +36,7 @@
 #       vfyled   = <num> ;                          # pin number
 #       usbvid   = <hexnum>;                        # USB VID (Vendor ID)
 #       usbpid   = <hexnum> [, <hexnum> ...]        # USB PID (Product ID) (1)
-#       usbdev   = <interface>;                     # USB interface or other device info 
+#       usbdev   = <interface>;                     # USB interface or other device info
 #       usbvendor = <vendorname>;                   # USB Vendor Name
 #       usbproduct = <productname>;                 # USB Product Name
 #       usbsn    = <serialno>;                      # USB Serial Number
@@ -148,9 +148,9 @@
 # complain.
 #
 # Parts can also inherit parameters from previously defined parts
-# using the following syntax. In this case specified integer and 
-# string values override parameter values from the parent part. New 
-# memory definitions are added to the definitions inherited from the 
+# using the following syntax. In this case specified integer and
+# string values override parameter values from the parent part. New
+# memory definitions are added to the definitions inherited from the
 # parent.
 #
 #   part parent <id>                              # quoted string
@@ -159,7 +159,7 @@
 #     ;
 #
 # NOTES:
-#   * 'devicecode' is the device code used by the STK500 (see codes 
+#   * 'devicecode' is the device code used by the STK500 (see codes
 #       listed below)
 #   * Not all memory types will implement all instructions.
 #   * AVR Fuse bits and Lock bits are implemented as a type of memory.
@@ -373,7 +373,7 @@ programmer
 # http://dangerousprototypes.com/docs/FT2232_breakout_board
 # http://www.ftdichip.com/Products/Modules/DLPModules.htm,DLP-2232*,DLP-USB1232H
 # http://flashrom.org/FT2232SPI_Programmer
-# 
+#
 # The drivers will look for a specific device and use the first one found.
 # If you have mulitple devices, then look for unique information (like SN)
 # And fill that in here.
@@ -415,7 +415,7 @@ programmer
   type       = "avrftdi";
   connection_type = usb;
   usbvid     = 0x0403;
-# Note: This PID is reserved for generic H devices and 
+# Note: This PID is reserved for generic H devices and
 # should be programmed into the EEPROM
 #  usbpid     = 0x8A48;
   usbpid     = 0x6010;
@@ -423,13 +423,13 @@ programmer
   usbvendor  = "";
   usbproduct = "";
   usbsn      = "";
-#ISP-signals 
+#ISP-signals
   reset  = 3;
   sck    = 0;
   mosi   = 1;
   miso   = 2;
   buff   = ~4;
-#LED SIGNALs 
+#LED SIGNALs
   errled = ~ 11;
   rdyled = ~ 14;
   pgmled = ~ 13;
@@ -527,8 +527,8 @@ programmer
 
 
 # On the adapter you can read "O-Link". On the PCB is printed "OpenJTAG v3.1"
-# You can find it as "OpenJTAG ARM JTAG USB" in the internet. 
-# (But there are also several projects called Open JTAG, eg. 
+# You can find it as "OpenJTAG ARM JTAG USB" in the internet.
+# (But there are also several projects called Open JTAG, eg.
 # http://www.openjtag.org, which are completely different.)
 #   http://www.100ask.net/shop/english.html (website seems to be outdated)
 #   http://item.taobao.com/item.htm?id=1559277013
@@ -806,7 +806,7 @@ programmer
 # TTL-232R TXD 4 Orange -> ICPS RESET (pin 5)
 # TTL-232R RXD 5 Yellow -> ICPS SCK   (pin 3)
 # TTL-232R RTS 6 Green  -> ICPS MISO  (pin 1)
-# Except for VCC and GND, you can connect arbitual pairs as long as 
+# Except for VCC and GND, you can connect arbitual pairs as long as
 # the following table is adjusted.
 programmer
   id    = "ttl232r";
@@ -909,7 +909,7 @@ programmer
   type  = "butterfly";
   connection_type = serial;
 ;
- 
+
 # suggested in http://forum.mikrokopter.de/topic-post48317.html
 programmer
   id    = "mkbutterfly";
@@ -1109,13 +1109,13 @@ programmer
   usbpid = 0x2111;
 ;
 
-#programmer
-#  id    = "xplainedpro_updi";
-#  desc  = "Atmel AVR XplainedPro in UPDI mode";
-#  type  = "jtagice3_updi";
-#  connection_type = usb;
-#  usbpid = 0x2111;
-#;
+programmer
+  id    = "xplainedpro_updi";
+  desc  = "Atmel AVR XplainedPro in UPDI mode";
+  type  = "jtagice3_updi";
+  connection_type = usb;
+  usbpid = 0x2111;
+;
 
 programmer
   id    = "xplainedmini";
@@ -1133,13 +1133,13 @@ programmer
   usbpid = 0x2145;
 ;
 
-#programmer
-#  id    = "xplainedmini_updi";
-#  desc  = "Atmel AVR XplainedMini in UPDI mode";
-#  type  = "jtagice3_updi";
-#  connection_type = usb;
-#  usbpid = 0x2145;
-#;
+programmer
+  id    = "xplainedmini_updi";
+  desc  = "Atmel AVR XplainedMini in UPDI mode";
+  type  = "jtagice3_updi";
+  connection_type = usb;
+  usbpid = 0x2145;
+;
 
 programmer
   id    = "atmelice";
@@ -1157,13 +1157,13 @@ programmer
   usbpid = 0x2141;
 ;
 
-#programmer
-#  id    = "atmelice_updi";
-#  desc  = "Atmel-ICE (ARM/AVR) in UPDI mode";
-#  type  = "jtagice3_updi";
-#  connection_type = usb;
-#  usbpid = 0x2141;
-#;
+programmer
+  id    = "atmelice_updi";
+  desc  = "Atmel-ICE (ARM/AVR) in UPDI mode";
+  type  = "jtagice3_updi";
+  connection_type = usb;
+  usbpid = 0x2141;
+;
 
 programmer
   id    = "atmelice_dw";
@@ -1197,13 +1197,13 @@ programmer
   usbpid = 0x2144;
 ;
 
-#programmer
-#  id    = "powerdebugger_updi";
-#  desc  = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
-#  type  = "jtagice3_updi";
-#  connection_type = usb;
-#  usbpid = 0x2144;
-#;
+programmer
+  id    = "powerdebugger_updi";
+  desc  = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
+  type  = "jtagice3_updi";
+  connection_type = usb;
+  usbpid = 0x2144;
+;
 
 programmer
   id    = "powerdebugger_dw";
@@ -1284,7 +1284,7 @@ programmer
 programmer parent "stk200"
   id    = "pony-stk200";
   desc  = "Pony Prog STK200";
-  pgmled = 8; 
+  pgmled = 8;
 ;
 
 programmer
@@ -1369,7 +1369,7 @@ programmer
 # From the contributor of the "xil" jtag cable:
 # The "vcc" definition isn't really vcc (the cable gets its power from
 # the programming circuit) but is necessary to switch one of the
-# buffer lines (trying to add it to the "buff" lines doesn't work in 
+# buffer lines (trying to add it to the "buff" lines doesn't work in
 # avrdude versions before 5.5j).
 # With this, TMS connects to RESET, TDI to MOSI, TDO to MISO and TCK
 # to SCK (plus vcc/gnd of course)
@@ -1479,7 +1479,7 @@ programmer
 #  miso  = ?;
 #;
 
-# some ultra cheap programmers use bitbanging on the 
+# some ultra cheap programmers use bitbanging on the
 # serialport.
 #
 # PC - DB9 - Pins for RS232:
@@ -2129,7 +2129,7 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1 0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = "1 0  1  0   0  0  0  0   x x x x  x x x x",
                           "x x a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1 1  0  0   0  0  0  0   x x x x  x x x x",
@@ -2242,7 +2242,7 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
+        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8",
                           "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
@@ -2355,7 +2355,7 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
@@ -2469,7 +2469,7 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
@@ -2596,7 +2596,7 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 0  0 0 0 0", 
+        read            = "1  0  1  0   0  0  0  0   0 0 0 0  0 0 0 0",
                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1  1  0  0   0  0  0  0   0 0 0 0  0 0 0 0",
@@ -2720,7 +2720,7 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
@@ -2814,7 +2814,7 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
@@ -2928,7 +2928,7 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
+        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8",
                           "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
@@ -3041,7 +3041,7 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x a8", 
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x a8",
                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
@@ -3169,7 +3169,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	mode		= 0x04;
@@ -3321,7 +3321,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	mode		= 0x04;
@@ -3505,7 +3505,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	mode		= 0x04;
@@ -3686,7 +3686,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -4261,7 +4261,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -4463,7 +4463,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -4671,7 +4671,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -4879,7 +4879,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -5073,7 +5073,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -5257,7 +5257,7 @@ part
        mode        = 0x41;
     delay       = 10;
     blocksize   = 128;
-    readsize    = 256;  
+    readsize    = 256;
 
         ;
 
@@ -5617,7 +5617,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -6538,7 +6538,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	mode		= 0x04;
@@ -7812,7 +7812,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -8024,7 +8024,7 @@ part
 
 	write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -8233,7 +8233,7 @@ part
                           " 0 0 0 x x x x a8",
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " o o o o o o o o";
-    
+
         write           = " 1 1 0 0 0 0 0 0",
                           " 0 0 0 x x x x a8",
                           " a7 a6 a5 a4 a3 a2 a1 a0",
@@ -8268,22 +8268,22 @@ part
                           " 0 0 0 a12 a11 a10 a9 a8",
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " o o o o o o o o";
-        
+
         read_hi          = " 0 0 1 0 1 0 0 0",
                            " 0 0 0 a12 a11 a10 a9 a8",
                            " a7 a6 a5 a4 a3 a2 a1 a0",
                            " o o o o o o o o";
-        
+
         loadpage_lo     = " 0 1 0 0 0 0 0 0",
                           " 0 0 0 x x x x x",
                           " x x a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
-        
+
         loadpage_hi     = " 0 1 0 0 1 0 0 0",
                           " 0 0 0 x x x x x",
                           " x x a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
-        
+
         writepage       = " 0 1 0 0 1 1 0 0",
                           " 0 0 0 a12 a11 a10 a9 a8",
                           " a7 a6 x x x x x x",
@@ -8295,57 +8295,57 @@ part
         readsize    = 256;
 
         ;
-        
+
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
                           "x x x x x x x x i i i i i i i i";
         ;
-    
+
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
                           "x x x x x x x x i i i i i i i i";
         ;
-    
+
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
                           "x x x x x x x x x x x x x i i i";
         ;
-    
+
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
                           "x x x x x x x x x x o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
                           "x x x x x x x x 1 1 i i i i i i";
         ;
-    
+
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
                           "0 0 0 0 0 0 0 0 o o o o o o o o";
         ;
-    
+
     memory "signature"
         size            = 3;
         read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
@@ -8809,7 +8809,7 @@ part parent "m328"
         max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
                           "x x x x x x x x x x i i i i i i";
     ;
@@ -9469,7 +9469,7 @@ part parent "pwm3b"
 part parent "pwm316"
      id = "pwm216";
      desc = "AT90PWM216";
-  ; 
+  ;
 
 #------------------------------------------------------------
 # ATtiny25
@@ -10097,7 +10097,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -10287,7 +10287,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -10490,7 +10490,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -11788,7 +11788,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -11979,7 +11979,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -12183,7 +12183,7 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
 	loadpage_lo	= "  1   1   0   0      0   0   0   1",
@@ -15210,10 +15210,9 @@ part
 part
     id		= ".avr8x";
     desc	= "AVR8X family common values";
-#    has_updi	= yes;
-    has_pdi	= yes;
+    has_updi	= yes;
     nvm_base	= 0x1000;
-#    ocd_base	= 0x0F80;
+    ocd_base	= 0x0F80;
 
     memory "signature"
         size		= 3;
@@ -15390,7 +15389,7 @@ part parent    ".avr8x_tiny"
 ;
 
 #------------------------------------------------------------
-# ATtiny402w = workaround to address wrong device signature on some chips
+# ATtiny402w = workaround to address wrong device signature (0x25) on some chips
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
@@ -15435,6 +15434,7 @@ part parent    ".avr8x_tiny"
         page_size = 0x20;
         readsize  = 0x100;
     ;
+
 ;
 
 #------------------------------------------------------------
@@ -16161,10 +16161,196 @@ part parent    ".avr8x_mega"
     ;
 ;
 
+
+#------------------------------------------------------------
+# AVR DA family common values
+#------------------------------------------------------------
+
+part
+    id    = ".avrda";
+    desc  = "AVRDA family common values";
+    has_updi  = yes;
+    nvm_base  = 0x1000;
+    ocd_base  = 0x0F80;
+    rampz     = 0x0B;
+
+    memory "signature"
+        size    = 3;
+        offset    = 0x1100;
+    ;
+
+    memory "prodsig"
+        size    = 0x3D;
+        offset    = 0x1103;
+        page_size = 0x3D;
+        readsize  = 0x3D;
+    ;
+
+    memory "fuses"
+        size    = 9;
+        offset    = 0x1050;
+    ;
+
+    memory "fuse0"
+        size    = 1;
+        offset    = 0x1050;
+    ;
+
+    memory "fuse1"
+        size    = 1;
+        offset    = 0x1051;
+    ;
+
+    memory "fuse2"
+        size    = 1;
+        offset    = 0x1052;
+    ;
+
+    memory "fuse5"
+        size    = 1;
+        offset    = 0x1055;
+    ;
+
+    memory "fuse6"
+        size    = 1;
+        offset    = 0x1056;
+    ;
+
+    memory "fuse7"
+        size    = 1;
+        offset    = 0x1057;
+    ;
+
+    memory "fuse8"
+        size    = 1;
+        offset    = 0x1058;
+    ;
+
+    memory "lock"
+        size    = 4;
+        offset    = 0x1040;
+    ;
+
+    memory "data"
+        # SRAM, only used to supply the offset
+        offset    = 0x1000000;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR128DA64
+#------------------------------------------------------------
+
+part parent    ".avrda"
+    id        = "avr128da64";
+    desc      = "AVR128DA64";
+    signature = 0x1E 0x97 0x07;
+
+    memory "flash"
+        size      = 0x20000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x100;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x20;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR128DA48
+#------------------------------------------------------------
+
+part parent    ".avrda"
+    id        = "avr128da48";
+    desc      = "AVR128DA48";
+    signature = 0x1E 0x97 0x08;
+
+    memory "flash"
+        size      = 0x20000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x100;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x20;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR128DA32
+#------------------------------------------------------------
+
+part parent    ".avrda"
+    id        = "avr128da32";
+    desc      = "AVR128DA32";
+    signature = 0x1E 0x97 0x09;
+
+    memory "flash"
+        size      = 0x20000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x20;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR128DA28
+#------------------------------------------------------------
+
+part parent    ".avrda"
+    id        = "avr128da28";
+    desc      = "AVR128DA28";
+    signature = 0x1E 0x97 0x0A;
+
+    memory "flash"
+        size      = 0x20000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x100;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x20;
+        readsize  = 0x100;
+    ;
+;
+
+
+
+
+
+
 programmer
   id    = "jtag2updi";
   desc  = "JTAGv2 to UPDI bridge";
   type  = "jtagmkii_pdi";
   connection_type = serial;
   baudrate = 115200;
+;
+
+programmer
+  id    = "snap_updi";
+  desc  = "MPLAB SNAP in UPDI mode";
+  type  = "jtagice3_updi";
+  connection_type = usb;
+  usbvid = 0x04D8;
+  usbpid = 0x9018;
 ;

--- a/source/JICE_io.cpp
+++ b/source/JICE_io.cpp
@@ -11,11 +11,15 @@
 #include "sys.h"
 #include "dbg.h"
 
+#ifndef DISABLE_HOST_TIMEOUT
 #define loop_until_bit_set_or_host_timeout(register,bitpos) ({ \
   SYS::startTimer(); \
   while(!((register&(1<<bitpos))||(SYS::checkTimeouts() & WAIT_FOR_HOST))); \
   SYS::stopTimer(); \
 })
+#else
+#define loop_until_bit_set_or_host_timeout(register,bitpos) loop_until_bit_is_set(register,bitpos)
+#endif
 
 namespace {
   // *** Baud rate lookup table for UBRR0 register ***

--- a/source/JICE_io.cpp
+++ b/source/JICE_io.cpp
@@ -3,97 +3,90 @@
  *
  * Created: 18-11-2017 15:20:29
  *  Author: JMR_2
- */ 
+ */
 
 // Includes
 #include <avr/io.h>
 #include "JICE_io.h"
 #include "sys.h"
+#include "dbg.h"
+
+#define loop_until_bit_set_or_host_timeout(register,bitpos) ({ \
+  SYS::startTimer(); \
+  while(!((register&(1<<bitpos))||(SYS::checkTimeouts() & WAIT_FOR_HOST))); \
+  SYS::stopTimer(); \
+})
 
 namespace {
-	// *** Baud rate lookup table for UBRR0 register ***
-	// Indexed by valid values for PARAM_BAUD_RATE_VAL (defined in JTAG2.h)
-	FLASH<uint16_t> baud_tbl[8] = {baud_reg_val(2400), baud_reg_val(4800), baud_reg_val(9600), baud_reg_val(19200), baud_reg_val(38400), baud_reg_val(57600), baud_reg_val(115200), baud_reg_val(14400)};
+  // *** Baud rate lookup table for UBRR0 register ***
+  // Indexed by valid values for PARAM_BAUD_RATE_VAL (defined in JTAG2.h)
+  FLASH<uint16_t> baud_tbl[8] = {baud_reg_val(2400), baud_reg_val(4800), baud_reg_val(9600), baud_reg_val(19200), baud_reg_val(38400), baud_reg_val(57600), baud_reg_val(115200), baud_reg_val(14400)};
 }
 
 // Functions
 uint8_t JICE_io::put(char c) {
-#ifdef __AVR_ATmega16__
-	loop_until_bit_is_set(UCSRA, UDRE);
-	return UDR = c;
-#elif defined XTINY
-	loop_until_bit_is_set(HOST_USART.STATUS, USART_DREIF_bp);
-	return HOST_USART.TXDATAL = c;
+#if defined XAVR
+  loop_until_bit_is_set(HOST_USART.STATUS, USART_DREIF_bp);
+  HOST_USART.STATUS=1<<USART_TXCIF_bp;
+  return HOST_USART.TXDATAL = c;
 #else
-	loop_until_bit_is_set(UCSR0A, UDRE0);
-	return UDR0 = c;
+  loop_until_bit_is_set(UCSR0A, UDRE0);
+  UCSR0A|=1<<TXC0;
+  return UDR0 = c;
 #endif
 }
 
 uint8_t JICE_io::get(void) {
-#ifdef __AVR_ATmega16__
-	loop_until_bit_is_set(UCSRA, RXC); /* Wait until data exists. */
-	return UDR;
-#elif defined XTINY
-	loop_until_bit_is_set(HOST_USART.STATUS, USART_RXCIF_bp); /* Wait until data exists. */
-	return HOST_USART.RXDATAL;
+#if defined XAVR
+  loop_until_bit_set_or_host_timeout(HOST_USART.STATUS, USART_RXCIF_bp); /* Wait until data exists. */
+  //while (HOST_USART.STATUS USART_RXCIF_bp);
+  return HOST_USART.RXDATAL;
 #else
-	loop_until_bit_is_set(UCSR0A, RXC0); /* Wait until data exists. */
-	return UDR0;
+  //loop_(until_bit_is_set(UCSR0A, RXC0); /* Wait until data exists. */
+  loop_until_bit_set_or_host_timeout(UCSR0A, RXC0);
+  return UDR0;
 #endif
 }
 
 void JICE_io::init(void) {
-#ifdef __AVR_ATmega16__
-	/* Set double speed */
-	UCSRA = (1<<U2X);
-	/* Set initial baud rate */
-	UBRRH = 0;
-	UBRRL = baud_reg_val(19200);
-	/* Enable receiver and transmitter */
-	UCSRB = (1<<RXEN)|(1<<TXEN);
-	/* Set frame format: 8data, 1stop bit */
-	UCSRC = (1<<URSEL)|(1<<UCSZ0)|(1<<UCSZ1);
-#elif defined XTINY
-	// Init TxD pin (PA6 on tiny412)
-	PORT(HOST_TX_PORT) |= 1 << HOST_TX_PIN;
-	DDR(HOST_TX_PORT) |= 1 << HOST_TX_PIN;
-	/* Set initial baud rate */
-	HOST_USART.BAUD = baud_reg_val(19200);
-	/* Enable receiver and transmitter */
-	HOST_USART.CTRLB = USART_TXEN_bm | USART_RXEN_bm | USART_RXMODE_NORMAL_gc;
+#if defined XAVR
+  // Init TxD pin (PA6 on tiny412)
+  PORT(HOST_TX_PORT) |= 1 << HOST_TX_PIN;
+  DDR(HOST_TX_PORT) |= 1 << HOST_TX_PIN;
+  /* Set initial baud rate */
+  HOST_USART.BAUD = baud_reg_val(19200);
+  /* Enable receiver and transmitter */
+  HOST_USART.CTRLB = USART_TXEN_bm | USART_RXEN_bm | USART_RXMODE_NORMAL_gc;
 #else
-	/* Set double speed */
-	UCSR0A = (1<<U2X0);
-	/* Set initial baud rate */
-	UBRR0 = baud_reg_val(19200);
-	/* Enable receiver and transmitter */
-	UCSR0B = (1<<RXEN0)|(1<<TXEN0);
-	/* Set frame format: 8data, 1stop bit */
-	UCSR0C = (1<<UCSZ00)|(1<<UCSZ01);
+  /* Set double speed */
+  UCSR0A = (1<<U2X0);
+  /* Set initial baud rate */
+  UBRR0 = baud_reg_val(19200);
+  /* Enable receiver and transmitter */
+  UCSR0B = (1<<RXEN0)|(1<<TXEN0);
+  /* Set frame format: 8data, 1stop bit */
+  /* this is default configuration, so leave it */
+  //#ifdef URSEL //the one case where we can't handle the weird UART on atmega16 with #defines to rename registers...
+  //UCSRC = (1<<URSEL)|(1<<UCSZ0)|(1<<UCSZ1);
+  //#else
+  //UCSR0C = (1<<UCSZ00)|(1<<UCSZ01);
+  //#endif
 #endif
 }
 
+
 void JICE_io::flush(void) {
-#ifdef __AVR_ATmega16__
-	UCSRA |= 1 << TXC;
-	loop_until_bit_is_set(UCSRA, TXC);
-#elif defined XTINY
-	HOST_USART.STATUS = 1 << USART_TXCIF_bp;
-	loop_until_bit_is_set(HOST_USART.STATUS, USART_TXCIF_bp);
+#if defined(XAVR)
+  loop_until_bit_set_or_host_timeout(HOST_USART.STATUS, USART_TXCIF_bp);
 #else
-	UCSR0A |= 1 << TXC0;
-	loop_until_bit_is_set(UCSR0A, TXC0);
+  loop_until_bit_set_or_host_timeout(UCSR0A, TXC0);
 #endif
 }
 
 void JICE_io::set_baud(JTAG2::baud_rate rate) {
-#ifdef __AVR_ATmega16__
-	UBRRH = 0;
-	UBRRL = baud_tbl[rate - 1];
-#elif defined XTINY
-	HOST_USART.BAUD = baud_tbl[rate - 1];
+#if defined XAVR
+  HOST_USART.BAUD = baud_tbl[rate - 1];
 #else
-	UBRR0 = baud_tbl[rate - 1];
+  UBRR0 = baud_tbl[rate - 1];
 #endif
 }

--- a/source/JTAG2.cpp
+++ b/source/JTAG2.cpp
@@ -1,378 +1,634 @@
 /*
- * STK500.cpp
- *
- * Created: 08-12-2017 19:47:27
- *  Author: JMR_2
- */
+   STK500.cpp
+
+   Created: 08-12-2017 19:47:27
+    Author: JMR_2
+*/
 
 #include "JTAG2.h"
 #include "JICE_io.h"
 #include "NVM.h"
+#include "NVM_v2.h"
 #include "crc16.h"
 #include "UPDI_hi_lvl.h"
+#include "dbg.h"
 
 // *** Writeable Parameter Values ***
-JTAG2::emul_mode JTAG2::PARAM_EMU_MODE_VAL;
+uint8_t JTAG2::PARAM_EMU_MODE_VAL;
 JTAG2::baud_rate JTAG2::PARAM_BAUD_RATE_VAL;
-
+uint8_t JTAG2::ConnectedTo;
 // *** STK500 packet ***
 JTAG2::packet_t JTAG2::packet;
 
 // Local objects
 namespace {
-	// *** Local variables ***
-	uint8_t flash_pagesize;
-	uint8_t eeprom_pagesize;
+// *** Local variables ***
+uint16_t flash_pagesize;
+uint8_t eeprom_pagesize;
+uint8_t nvm_version = 1;
 
-	// *** Local functions declaration ***
-	void NVM_fuse_write (uint16_t address, uint8_t data);
-	void NVM_buffered_write(uint16_t address, uint16_t lenght, uint8_t buff_size, uint8_t write_type);
-	
-	// *** Signature response message ***
-	FLASH<uint8_t> sgn_resp[29] {	JTAG2::RSP_SIGN_ON, 1,
-		1, JTAG2::PARAM_FW_VER_M_MIN_VAL, JTAG2::PARAM_FW_VER_M_MAJ_VAL, JTAG2::PARAM_HW_VER_M_VAL,
-		1, JTAG2::PARAM_FW_VER_S_MIN_VAL, JTAG2::PARAM_FW_VER_S_MAJ_VAL, JTAG2::PARAM_HW_VER_S_VAL,
-		0, 0, 0, 0, 0, 0,
-		'J', 'T', 'A', 'G', 'I', 'C', 'E', ' ', 'm', 'k', 'I', 'I', 0};
+// *** Local functions declaration ***
+void NVM_fuse_write (uint16_t address, uint8_t data);
+void NVM_v2_write (uint32_t address, uint16_t length, uint8_t flash_cmd);
+void NVM_buffered_write(uint16_t address, uint16_t length, uint8_t buff_size, uint8_t write_type);
+
+// *** Signature response message ***
+FLASH<uint8_t> sgn_resp[29] { JTAG2::RSP_SIGN_ON, 1,
+                              1, JTAG2::PARAM_FW_VER_M_MIN_VAL, JTAG2::PARAM_FW_VER_M_MAJ_VAL, JTAG2::PARAM_HW_VER_M_VAL,
+                              1, JTAG2::PARAM_FW_VER_S_MIN_VAL, JTAG2::PARAM_FW_VER_S_MAJ_VAL, JTAG2::PARAM_HW_VER_S_VAL,
+                              0, 0, 0, 0, 0, 0,
+                              'J', 'T', 'A', 'G', 'I', 'C', 'E', ' ', 'm', 'k', 'I', 'I', 0
+                            };
 }
 
-// *** Initialization functions ***
-	void JTAG2::init() {
-		// Initialize JTAGICE2 variables
-		JTAG2::PARAM_EMU_MODE_VAL = JTAG2::emul_mode::EMULATOR_MODE_PDI;
-		JTAG2::PARAM_BAUD_RATE_VAL = JTAG2::baud_rate::baud_19200;
-	}
+// *** Packet functions ***
+bool JTAG2::receive() {
+  while (JICE_io::get() != MESSAGE_START) {
+    if ((SYS::checkTimeouts() & WAIT_FOR_HOST)) return false;
+  }
+  uint16_t crc = CRC::next(MESSAGE_START);
+  for (uint16_t i = 0; i < 6; i++) {
+    crc = CRC::next(packet.raw[i] = JICE_io::get(), crc);
+  }
+  if (packet.size_word[0] > sizeof(packet.body)) return false;
+  if (JICE_io::get() != TOKEN) return false;
+  crc = CRC::next(TOKEN, crc);
+  for (uint16_t i = 0; i < packet.size_word[0]; i++) {
+    crc = CRC::next(packet.body[i] = JICE_io::get(), crc);
+  }
+  if ((uint16_t)(JICE_io::get() | (JICE_io::get() << 8)) != crc) return false;
+  return true;
+}
 
-// *** Packet functions *** 
-	bool JTAG2::receive() {
-		while (JICE_io::get() != MESSAGE_START);
-		uint16_t crc = CRC::next(MESSAGE_START);
-		for (uint16_t i = 0; i < 6; i++) {
-			crc = CRC::next(packet.raw[i] = JICE_io::get(), crc);
-		}
-		if (packet.size_word[0] > sizeof(packet.body)) return false;
-		if (JICE_io::get() != TOKEN) return false;
-		crc = CRC::next(TOKEN, crc);
-		for (uint16_t i = 0; i < packet.size_word[0]; i++) {
-			crc = CRC::next(packet.body[i] = JICE_io::get(), crc);
-		}
-		if ((uint16_t)(JICE_io::get() | (JICE_io::get() << 8)) != crc) return false;
-		return true;
-	}
+void JTAG2::answer() {
+  uint16_t crc = CRC::next(JICE_io::put(MESSAGE_START));
+  for (uint16_t i = 0; i < 6; i++) {
+    crc = CRC::next(JICE_io::put(packet.raw[i]), crc);
+  }
+  crc = CRC::next(JICE_io::put(TOKEN), crc);
+  for (uint16_t i = 0; i < packet.size_word[0]; i++) {
+    crc = CRC::next(JICE_io::put(packet.body[i]), crc);
+  }
+  JICE_io::put(crc);
+  JICE_io::put(crc >> 8);
+}
 
-	void JTAG2::answer() {
-		uint16_t crc = CRC::next(JICE_io::put(MESSAGE_START));
-		for (uint16_t i = 0; i < 6; i++) {
-			crc = CRC::next(JICE_io::put(packet.raw[i]), crc);
-		}
-		crc = CRC::next(JICE_io::put(TOKEN), crc);
-		for (uint16_t i = 0; i < packet.size_word[0]; i++) {
-			crc = CRC::next(JICE_io::put(packet.body[i]), crc);
-		}
-		JICE_io::put(crc);
-		JICE_io::put(crc >> 8);
-	}
-	
-	void JTAG2::delay_exec() {
-		// wait for transmission complete
-		JICE_io::flush();
-		// set baud rate
-		JICE_io::set_baud(PARAM_BAUD_RATE_VAL);
-		
-		// disable UPDI unit if requested
-		if (JTAG2::PARAM_EMU_MODE_VAL != EMULATOR_MODE_PDI) {
-			UPDI::disable();
-			JTAG2::PARAM_EMU_MODE_VAL = EMULATOR_MODE_PDI;
-		}
-	}
+void JTAG2::delay_exec() {
+  // wait for transmission complete
+  JICE_io::flush();
+  // set baud rate
+  JICE_io::set_baud(PARAM_BAUD_RATE_VAL);
+}
 
 // *** Set status function ***
-	void JTAG2::set_status(uint8_t status_code){
-		packet.size_word[0] = 1;
-		packet.body[0] = status_code;
-	}
+void JTAG2::set_status(uint8_t status_code) {
+  packet.size_word[0] = 1;
+  packet.body[0] = status_code;
+}
 
 // *** General command functions ***
 
-	void JTAG2::sign_on(){
-		/* Initialize or enable UPDI */
-		UPDI_io::put(UPDI_io::double_break);
-		UPDI::stcs(UPDI::reg::Control_A, 6);
-		// Send sign on message
-		packet.size_word[0] = sizeof(sgn_resp);
-		for (uint8_t i = 0; i < sizeof(sgn_resp); i++) {
-			packet.body[i] = sgn_resp[i];
-		}
-		// Append UPDI System Information Block (SIB) to sign-on response for debugging purposes 		
-#		ifdef READ_SIB
-		packet.size_word[0] += READ_SIB;
-		uint8_t (& sib)[READ_SIB] = *(uint8_t (*)[READ_SIB]) (packet.body + sizeof(sgn_resp));
-		UPDI::read_sib(sib);
-#		endif
-	}
+void JTAG2::sign_on() {
+  // Initialize JTAGICE2 variables
+  JTAG2::PARAM_EMU_MODE_VAL = 0x02;
+  JTAG2::PARAM_BAUD_RATE_VAL = JTAG2::baud_19200;
+  // Send sign on message
+  packet.size_word[0] = sizeof(sgn_resp);
+  for (uint8_t i = 0; i < sizeof(sgn_resp); i++) {
+    packet.body[i] = sgn_resp[i];
+  }
+  JTAG2::ConnectedTo |= 0x01; //now connected to host
+}
 
-	void JTAG2::get_parameter(){
-		uint8_t & status = packet.body[0];
-		uint8_t & parameter = packet.body[1];
-		switch (parameter) {
-			case PARAM_HW_VER:
-				packet.size_word[0] = 3;
-				packet.body[1] = PARAM_HW_VER_M_VAL;
-				packet.body[2] = PARAM_HW_VER_S_VAL;
-				break;
-			case PARAM_FW_VER:
-				packet.size_word[0] = 5;
-				packet.body[1] = PARAM_FW_VER_M_MIN_VAL;
-				packet.body[2] = PARAM_FW_VER_M_MAJ_VAL;
-				packet.body[3] = PARAM_FW_VER_S_MIN_VAL;
-				packet.body[4] = PARAM_FW_VER_S_MAJ_VAL;
-				break;
-			case PARAM_EMU_MODE:
-				packet.size_word[0] = 2;
-				packet.body[1] = PARAM_EMU_MODE_VAL;
-				break;
-			case PARAM_BAUD_RATE:
-				packet.size_word[0] = 2;
-				packet.body[1] = PARAM_BAUD_RATE_VAL;
-				break;
-			case PARAM_VTARGET:
-				packet.size_word[0] = 3;
-				packet.body[1] = PARAM_VTARGET_VAL & 0xFF;
-				packet.body[2] = PARAM_VTARGET_VAL >> 8;
-				break;
-			default:
-				set_status(RSP_ILLEGAL_PARAMETER);
-				return;
-		}
-		status = RSP_PARAMETER;
-		return;
-	}
+void JTAG2::get_parameter() {
+  uint8_t & status = packet.body[0];
+  uint8_t & parameter = packet.body[1];
+  switch (parameter) {
+    case PARAM_HW_VER:
+      packet.size_word[0] = 3;
+      packet.body[1] = PARAM_HW_VER_M_VAL;
+      packet.body[2] = PARAM_HW_VER_S_VAL;
+      break;
+    case PARAM_FW_VER:
+      packet.size_word[0] = 5;
+      packet.body[1] = PARAM_FW_VER_M_MIN_VAL;
+      packet.body[2] = PARAM_FW_VER_M_MAJ_VAL;
+      packet.body[3] = PARAM_FW_VER_S_MIN_VAL;
+      packet.body[4] = PARAM_FW_VER_S_MAJ_VAL;
+      break;
+    case PARAM_EMU_MODE:
+      packet.size_word[0] = 2;
+      packet.body[1] = PARAM_EMU_MODE_VAL;
+      break;
+    case PARAM_BAUD_RATE:
+      packet.size_word[0] = 2;
+      packet.body[1] = PARAM_BAUD_RATE_VAL;
+      break;
+    case PARAM_VTARGET:
+      packet.size_word[0] = 3;
+      packet.body[1] = PARAM_VTARGET_VAL & 0xFF;
+      packet.body[2] = PARAM_VTARGET_VAL >> 8;
+      break;
+    default:
+      set_status(RSP_ILLEGAL_PARAMETER);
+      return;
+  }
+  status = RSP_PARAMETER;
+  return;
+}
 
-	void JTAG2::set_parameter(){
-		uint8_t & parameter = packet.body[1];
-		switch (parameter) {
-			case PARAM_EMU_MODE:
-				PARAM_EMU_MODE_VAL = (emul_mode) packet.body[2];
-				break;
-			case PARAM_BAUD_RATE:
-				PARAM_BAUD_RATE_VAL = (baud_rate) packet.body[2];
-				break;
-			default:
-				set_status(RSP_ILLEGAL_PARAMETER);
-				return;
-		}
-		set_status(RSP_OK);
-	}
+void JTAG2::set_parameter() {
+  uint8_t & parameter = packet.body[1];
+  switch (parameter) {
+    case PARAM_EMU_MODE:
+      PARAM_EMU_MODE_VAL = packet.body[2];
+      break;
+    case PARAM_BAUD_RATE:
+      PARAM_BAUD_RATE_VAL = (baud_rate)packet.body[2];
+      break;
+    default:
+      set_status(RSP_ILLEGAL_PARAMETER);
+      return;
+  }
+  set_status(RSP_OK);
+}
 
-	void JTAG2::set_device_descriptor(){
-		flash_pagesize = packet.body[244];
-		eeprom_pagesize = packet.body[246];
-		set_status(RSP_OK);
-	}
-		
+void JTAG2::set_device_descriptor() {
+  flash_pagesize = packet.body[244];
+  eeprom_pagesize = packet.body[246];
+  // Now they've told us what we're talking to, and we will try to connect to it
+  /* Initialize or enable UPDI */
+  UPDI_io::put(UPDI_io::double_break);
+  UPDI::stcs(UPDI::reg::Control_A, 0x06);
+  uint8_t sib[16];
+  UPDI::read_sib(sib);
+  #if defined(DEBUG_ON)
+  DBG::debug(sib, 16, 1);
+  #endif
+
+  if (sib[10] == '2') {
+    nvm_version = 2;
+  } else {
+    nvm_version = 1;
+  }
+  packet.size_word[0] = 20;
+  packet.body[1] = 'S';
+  packet.body[2] = 'I';
+  packet.body[3] = 'B';
+  for (uint8_t i = 0; i < 16; i++) {
+    packet.body[i + 4] = sib[i];
+  }
+  JTAG2::ConnectedTo |= 0x01; //now connected to target
+  set_status(RSP_OK);
+}
+
 // *** Target mode set functions ***
-	// *** Sets MCU in program mode, if possibe ***
-	void JTAG2::enter_progmode(){
-		// Reset the MCU now, to prevent the WDT (if active) to reset it at an unpredictable moment
-		UPDI::CPU_reset();
-		// Now we have time to enter program mode (this mode also disables the WDT)
-		const uint8_t system_status = UPDI::CPU_mode<0xEF>();
-		switch (system_status){
-			// in normal operation mode
-			case 0x82:
-				// Write NVN unlock key (allows read access to all addressing space)
-				UPDI::write_key(UPDI::NVM_Prog);
-				// Request reset
-				UPDI::CPU_reset();
-				// Wait for NVM unlock state
-				//while (UPDI::CPU_mode() != 0x08);
-			// already in program mode
-			case 0x08:
-				// better clear the page buffer, just in case.
-				UPDI::sts_b(NVM::NVM_base | NVM::CTRLA, NVM::PBC);
-				// Turn on LED to indicate program mode
-				SYS::setLED();
-				set_status(RSP_OK);
-				break;
-			// in other modes fail and inform host of wrong mode
-			default:
-				packet.size_word[0] = 2;
-				packet.body[0] = RSP_ILLEGAL_MCU_STATE;
-				packet.body[1] = system_status; // 0x01;
-		}
-	}
+// *** Sets MCU in program mode, if possibe ***
+void JTAG2::enter_progmode() {
+  //SYS::setVerLED();
+  // Reset the MCU now, to prevent the WDT (if active) to reset it at an unpredictable moment
+  UPDI::CPU_reset();
+  // Now we have time to enter program mode (this mode also disables the WDT)
+  const uint8_t system_status = UPDI::CPU_mode<0xEF>();
+  switch (system_status) {
+    // in normal operation mode
+    case 0x82:
+      // Write NVN unlock key (allows read access to all addressing space)
+      UPDI::write_key(UPDI::NVM_Prog);
+      // Request reset
+      UPDI::CPU_reset();
+    // Wait for NVM unlock state
+    //while (UPDI::CPU_mode() != 0x08);
+    // already in program mode
+    /* fall-thru */
+    case 0x08:
+      if (nvm_version == 1) {
+        // For NVM version 1 parts, there's a page buffer.
+        // It might have data in it if something else was writing to the flash when
+        // we so rudely interrupted, so better clear the page buffer, just in case.
+        uint8_t NVM_Status = UPDI::lds_b(NVM::NVM_base + NVM::STATUS);
+        uint8_t NVM_Cmnd = UPDI::lds_b(NVM::NVM_base + NVM::CTRLA);
+        if (NVM_Status || NVM_Cmnd ) {
+          #if defined(DEBUG_ON)
+          DBG::debug('d', NVM_Status,NVM_Cmnd);
+          #endif
+          UPDI::sts_b(NVM::NVM_base + NVM::STATUS, 0);
+          UPDI::sts_b(NVM::NVM_base + NVM::CTRLA, 0);
+        }
+        UPDI::sts_b(NVM::NVM_base | NVM::CTRLA, NVM::PBC);
+        // NVM version 2 parts don't have this, and trying to do this there annoys the NVM controller
+      } else {
+        uint8_t NVM_Status = UPDI::lds_b(NVM_v2::NVM_base + NVM_v2::STATUS);
+        uint8_t NVM_Cmnd = UPDI::lds_b(NVM_v2::NVM_base + NVM_v2::CTRLA);
+        if (NVM_Status || NVM_Cmnd ) {
+          #if defined(DEBUG_ON)
+          DBG::debug('d', NVM_Status,NVM_Cmnd);
+          #endif
+          UPDI::sts_b(NVM_v2::NVM_base + NVM_v2::STATUS, 0);
+          UPDI::sts_b(NVM_v2::NVM_base + NVM_v2::CTRLA, 0);
 
-	// *** Sets MCU in normal runnning mode, if possibe ***
-	void JTAG2::leave_progmode(){
-		const uint8_t system_status = UPDI::CPU_mode<0xEF>();
-		switch (system_status){
-			// in program mode
-			case 0x08:
-				// Request reset
-				UPDI::CPU_reset();
-				// Wait for normal mode
-				// while (UPDI::CPU_mode<0xEF>() != 0x82);
-			// already in normal mode
-			case 0x82:
-				// Turn off LED to indicate normal mode
-				SYS::clearLED();
-				set_status(RSP_OK);
-				break;
-			// in other modes fail and inform host of wrong mode
-			default:
-				packet.size_word[0] = 2;
-				packet.body[0] = RSP_ILLEGAL_MCU_STATE;
-				packet.body[1] = system_status; // 0x01;
-		}
-	}
-	
-// *** Read/Write/Erase functions ***
+        }
+      }
+        // Turn on LED to indicate program mode
+        SYS::setLED();
+        #if defined(DEBUG_ON)
+        DBG::debug('R',UPDI::lds_b(0x0F01));
+        #endif
+/*
+        UPDI::stptr_w(0x0F00);
+        UPDI::rep(31);
+        packet.body[1] = UPDI::ldinc_b();
+        for (uint16_t i = 2; i < 33; i++) {
+          packet.body[i] = UPDI_io::get();
+        }
+        UPDI::stptr_w(0x1100);
+        UPDI::rep(63);
+        packet.body[33] = UPDI::ldinc_b();
+        for (uint16_t i = 1; i < 63; i++) {
+          packet.body[33 + i] = UPDI_io::get();
+        }
+        DBG::debug("SYS", 1);
 
-	void JTAG2::read_mem() {
-		if (UPDI::CPU_mode() != 0x08){
-			// fail if not in program mode
-			packet.size_word[0] = 2;
-			packet.body[0] = RSP_ILLEGAL_MCU_STATE;
-			packet.body[1] = 0x01;
-		}
-		else {
-			// in program mode
-			const uint16_t NumBytes = (packet.body[3] << 8) | packet.body[2];
-			// Get physical address for reading
-			const uint16_t address = (packet.body[7] << 8) | packet.body[6];
-			// Set UPDI pointer to address
-			UPDI::stptr_w(address);
-			// Read block
-			UPDI::rep(NumBytes - 1);
-			packet.body[1] = UPDI::ldinc_b();
-			for (uint16_t i = 2; i <= NumBytes; i++) {
-				packet.body[i] = UPDI_io::get();
-			}
-			packet.size_word[0] = NumBytes + 1;
-			packet.body[0] = RSP_MEMORY;
-		}
-	}
-	
-	void JTAG2::write_mem() {
-		if (UPDI::CPU_mode() != 0x08){
-			// fail if not in program mode
-			packet.size_word[0] = 2;
-			packet.body[0] = RSP_ILLEGAL_MCU_STATE;
-			packet.body[1] = 0x01;
-		}
-		else {
-			// in program mode
-			const uint8_t mem_type = packet.body[1];
-			const uint16_t address = packet.body[6] | (packet.body[7] << 8);
-			const uint16_t lenght = packet.body[2] | (packet.body[3] << 8);							/* number of bytes to write */
-			const bool is_flash = ((mem_type == MTYPE_FLASH) || (mem_type == MTYPE_BOOT_FLASH));
-			const uint8_t buff_size = is_flash ? flash_pagesize : eeprom_pagesize;
-			const uint8_t write_cmnd = is_flash ? NVM::WP : NVM::ERWP;
-			switch (mem_type) {
-				case MTYPE_FUSE_BITS:
-				case MTYPE_LOCK_BITS:
-					NVM_fuse_write (address, packet.body[10]);
-					break;
-				case MTYPE_FLASH:
-				case MTYPE_BOOT_FLASH:
-				case MTYPE_EEPROM_XMEGA:
-				case MTYPE_USERSIG:
-					NVM_buffered_write(address, lenght, buff_size, write_cmnd);
-					break;
-				default:
-					set_status(RSP_ILLEGAL_MEMORY_TYPE);
-					return;
-			}
-			set_status(RSP_OK);
-		}
-	}
+        for (uint8_t i = 1; i < 33; i++) {
+          DBG::debugWriteByte(' ');
+          DBG::debugWriteHex(packet.body[i]);
+        }
+        DBG::debug("ID", 1);
+        for (uint8_t i = 33; i < 97; i++) {
+          DBG::debugWriteByte(' ');
+          DBG::debugWriteHex(packet.body[i]);
+        }
+*/
+        set_status(RSP_OK);
+        break;
+      // in other modes fail and inform host of wrong mode
+      default:
+        packet.body[0] = RSP_ILLEGAL_MCU_STATE;
+        packet.body[1] = system_status; // 0x01;
+      }
+  }
 
-	void JTAG2::erase() {
-		const uint8_t erase_type = packet.body[1];
-		const uint16_t address = packet.body[2] | (packet.body[3] << 8);
-		switch (erase_type) {
-			case 0:
-				// Write Chip Erase key
-				UPDI::write_key(UPDI::Chip_Erase);
-				// Request reset
-				UPDI::CPU_reset();
-				// Erase chip process exits program mode, reenter...
-				enter_progmode();
-				break;
-			case 4:
-			case 5:
-				NVM::wait<false>();
-				UPDI::sts_b(address, 0xFF);
-				NVM::command<false>(NVM::ER);
-				set_status(RSP_OK);
-				break;
-			case 6:
-			case 7:
-				break;
-			default:
-				set_status(RSP_FAILED);
-		}
-	}
+  // *** Sets MCU in normal runnning mode, if possibe ***
+  void JTAG2::leave_progmode() {
+    const uint8_t system_status = UPDI::CPU_mode<0xEF>();
+    switch (system_status) {
+      // in program mode
+      case 0x08:
+      //clear NVMCTRL.CTRLA
+      if (nvm_version==2) {
+        UPDI::sts_b(NVM_v2::NVM_base + NVM_v2::CTRLA, 0);
+      } else {
+        UPDI::sts_b(NVM::NVM_base | NVM::CTRLA, 0);
+      }
+      // Request reset
+        UPDI::CPU_reset();
+      // Wait for normal mode
+      // while (UPDI::CPU_mode<0xEF>() != 0x82);
+      // already in normal mode
+      /* fall-thru */
+      case 0x82:
+        // Turn off LED to indicate normal mode
+        SYS::clearLED();
+        set_status(RSP_OK);
+        break;
+      // in other modes fail and inform host of wrong mode
+      default:
+        packet.size_word[0] = 2;
+        packet.body[0] = RSP_ILLEGAL_MCU_STATE;
+        packet.body[1] = system_status; // 0x01;
+    }
+  }
 
-// *** Local functions definition ***
-namespace {
-	void NVM_fuse_write (uint16_t address, uint8_t data) {
-		// Setup UPDI pointer
-		UPDI::stptr_w(NVM::NVM_base + NVM::DATA_lo);
-		// Send data to the NVM controller
-		UPDI::stinc_b(data);
-		UPDI::stinc_b(0x00);
-		// Send address to the NVM controller
-		UPDI::stinc_b(address & 0xFF);
-		UPDI::stinc_b(address >> 8);
-		// Execute fuse write
-		NVM::command<false>(NVM::WFU);
-	}
-	
-	void NVM_buffered_write(const uint16_t address, const uint16_t length, const uint8_t buff_size, const uint8_t write_cmnd) {
-		uint8_t current_byte_index = 10;					/* Index of the first byte to send inside the JTAG2 command body */
-		uint16_t bytes_remaining = length;					/* number of bytes to write */
-		
-		// Sends a block of bytes from the command body to memory, using the UPDI interface
-		// On entry, the UPDI pointer must already point to the desired address
-		// On exit, the UPDI pointer points to the next byte after the last one written
-		// Returns updated index into the command body, pointing to the first unsent byte.
-		auto updi_send_block = [] (uint8_t count, uint8_t index) {
-			count--;
-			NVM::wait<true>();
-			UPDI::rep(count);
-			UPDI::stinc_b(JTAG2::packet.body[index]);
-			for (uint8_t i = count; i; i--) {
-				UPDI_io::put(JTAG2::packet.body[++index]);
-				UPDI_io::get();
-			}
-			return ++index;
-		};
+  // The final command to make the chip go back into normal mode, shudown UPDI, and start running normally
+  void JTAG2::go() {
+    UPDI::stcs(UPDI::reg::Control_B, 0x04); //set UPDISIS to tell it that we're done and it can stop running the UPDI peripheral.
+    JTAG2::ConnectedTo &= ~(0x02); //record that we're no longer talking to the target
+    set_status(RSP_OK);
+  }
 
-		// Setup UPDI pointer for block transfer
-		UPDI::stptr_w(address);
-		/* Check address alignment, calculate number of unaligned bytes to send */
-		uint8_t unaligned_bytes = (-address & (buff_size - 1));
-		if (unaligned_bytes > bytes_remaining) unaligned_bytes = bytes_remaining;
-		/* If there are unaligned bytes, they must be sent first */
-		if (unaligned_bytes) {
-			// Send unaligned block
-			current_byte_index = updi_send_block(unaligned_bytes, current_byte_index);
-			bytes_remaining -= unaligned_bytes;
-			NVM::command<true>(write_cmnd);
-		}
-		while (bytes_remaining) {
-			/* Send a buff_size amount of bytes */
-			if (bytes_remaining >= buff_size) {
-				current_byte_index = updi_send_block(buff_size, current_byte_index);
-				bytes_remaining -= buff_size;
-			}
-			/* Send a NumBytes amount of bytes */
-			else {
-				current_byte_index = updi_send_block(bytes_remaining, current_byte_index);
-				bytes_remaining = 0;
-			}
-			NVM::command<true>(write_cmnd);
-		}
-	}
+
+  // *** Read/Write/Erase functions ***
+
+  void JTAG2::read_mem() {
+    if (UPDI::CPU_mode() != 0x08) {
+      // fail if not in program mode
+      packet.size_word[0] = 2;
+      packet.body[0] = RSP_ILLEGAL_MCU_STATE;
+      packet.body[1] = 0x01;
+    }
+    else {
+      const bool is_flash = ((packet.body[1] == MTYPE_FLASH) || (packet.body[1] == MTYPE_BOOT_FLASH));
+      if (nvm_version == 1 || !is_flash) {
+        // in program mode
+        const uint16_t NumBytes = (packet.body[3] << 8) | packet.body[2];
+        // Get physical address for reading
+        const uint16_t address = (packet.body[7] << 8) | packet.body[6];
+        // Set UPDI pointer to address
+        if (NumBytes>1) {
+          UPDI::stptr_w(address);
+          // Read block
+          UPDI::rep(NumBytes - 1);
+          packet.body[1] = UPDI::ldinc_b();
+          for (uint16_t i = 2; i <= NumBytes; i++) {
+            packet.body[i] = UPDI_io::get();
+          }
+        } else {
+          packet.body[1]=UPDI::lds_b(address);
+        }
+        packet.size_word[0] = NumBytes + 1;
+        packet.body[0] = RSP_MEMORY;
+      } else { //nvm version 2, reading flash
+        const uint16_t NumBytes = (packet.body[3] << 8) | packet.body[2];
+        // Get physical address for reading
+        uint32_t address = (((uint32_t)packet.body[8]) << 16) + (((uint16_t)packet.body[7]) << 8) + packet.body[6];
+        // Set UPDI pointer to address
+        UPDI::stptr_l(address);
+        // Read block
+        uint16_t temp;
+        UPDI::rep((NumBytes >> 1) - 1);
+        temp = UPDI::ldinc_w();
+        packet.body[1] = temp & 0xFF;
+        packet.body[2] = temp >> 8;
+        for (uint16_t i = 3; i <= NumBytes; i++) {
+          packet.body[i] = UPDI_io::get();
+        }
+        packet.size_word[0] = NumBytes + 1;
+        packet.body[0] = RSP_MEMORY;
+      }
+
+    }
+  }
+
+  void JTAG2::write_mem() {
+    if (UPDI::CPU_mode() != 0x08) {
+      // fail if not in program mode
+      packet.size_word[0] = 2;
+      packet.body[0] = RSP_ILLEGAL_MCU_STATE;
+      packet.body[1] = 0x01;
+    }
+    else {
+      // in program mode
+
+      const uint8_t mem_type = packet.body[1];
+      const uint16_t length = packet.body[2] | (packet.body[3] << 8);             /* number of bytes to write */
+      const bool is_flash = ((mem_type == MTYPE_FLASH) || (mem_type == MTYPE_BOOT_FLASH));
+      if (nvm_version == 1) {
+        const uint16_t address = packet.body[6] | (packet.body[7] << 8);
+        const uint8_t buff_size = is_flash ? flash_pagesize : eeprom_pagesize;
+        const uint8_t write_cmnd = is_flash ? NVM::WP : NVM::ERWP;
+        switch (mem_type) {
+          case MTYPE_FUSE_BITS:
+          case MTYPE_LOCK_BITS:
+            NVM_fuse_write (address, packet.body[10]);
+            break;
+          case MTYPE_FLASH:
+          case MTYPE_BOOT_FLASH:
+          case MTYPE_EEPROM_XMEGA:
+          case MTYPE_USERSIG:
+            NVM_buffered_write(address, length, buff_size, write_cmnd);
+            break;
+          default:
+            set_status(RSP_ILLEGAL_MEMORY_TYPE);
+            return;
+        }
+      } else {
+        const uint32_t address = (((uint32_t)packet.body[8]) << 16) | (((uint16_t)packet.body[7]) << 8) | packet.body[6];
+        uint8_t write_cmd = NVM_v2::EEERWR;
+        switch (mem_type) {
+          case MTYPE_FLASH:
+          case MTYPE_BOOT_FLASH:
+            write_cmd = NVM_v2::FLWR;
+          /* fall-thru */
+          case MTYPE_FUSE_BITS:
+          case MTYPE_LOCK_BITS:
+          case MTYPE_EEPROM_XMEGA:
+          case MTYPE_USERSIG:
+            NVM_v2_write(address, length, write_cmd);
+            break;
+          default:
+            set_status(RSP_ILLEGAL_MEMORY_TYPE);
+            return;
+        }
+      }
+      set_status(RSP_OK);
+    }
+  }
+
+  void JTAG2::erase() {
+    const uint8_t erase_type = packet.body[1];
+    switch (erase_type) {
+      case 0:
+        // Write Chip Erase key
+        UPDI::write_key(UPDI::Chip_Erase);
+        // Request reset
+        UPDI::CPU_reset();
+        // Erase chip process exits program mode, reenter...
+        enter_progmode();
+        break;
+      case 4:
+      case 5:
+        if (nvm_version == 1) {
+          const uint16_t address = packet.body[2] | (packet.body[3] << 8);
+          NVM::wait<false>();
+          UPDI::sts_b(address, 0xFF);
+          NVM::command<false>(NVM::ER);
+          set_status(RSP_OK);
+        } else {
+          const uint32_t address = (((uint32_t)packet.body[4]) << 16) | (((uint16_t) packet.body[3]) << 8) | packet.body[2];
+          NVM_v2::wait<false>();
+          NVM_v2::command<false>(NVM_v2::FLPER);
+          UPDI::sts_b_l(address, 0xFF);
+          NVM_v2::command<false>(NVM_v2::NOOP);
+          set_status(RSP_OK);
+        }
+        break;
+      case 6:
+      case 7:
+        break;
+      default:
+        set_status(RSP_FAILED);
+    }
+  }
+
+  // *** Local functions definition ***
+  namespace {
+  void NVM_fuse_write (uint16_t address, uint8_t data) {
+    // Setup UPDI pointer
+    UPDI::stptr_w(NVM::NVM_base + NVM::DATA_lo);
+    // Send data to the NVM controller
+    UPDI::stinc_b(data);
+    UPDI::stinc_b(0x00);
+    // Send address to the NVM controller
+    UPDI::stinc_b(address & 0xFF);
+    UPDI::stinc_b(address >> 8);
+    // Execute fuse write
+    NVM::command<false>(NVM::WFU);
+  }
+
+
+  void NVM_v2_write (uint32_t address, uint16_t length, uint8_t write_cmd) {
+    uint16_t current_byte_index = 10;         /* Index of the first byte to send inside the JTAG2 command body */
+    // Send the write command
+    NVM_v2::command<false>(write_cmd);
+
+    if (length == 1) { //if just one byte wrote it with no looping
+      // write to memory
+      UPDI::sts_b_l(address, JTAG2::packet.body[current_byte_index]);
+    } else {
+      if (length < 4 || write_cmd != NVM_v2::FLWR ) // byte write for short flash writes and all eeprom writes
+      {
+        uint8_t bytes_remaining = length - 1;         /* number of bytes to write */
+        NVM_v2::command<false>(write_cmd);
+        // Set UPDI pointer to address
+        UPDI::stptr_l(address);
+        UPDI::rep(bytes_remaining);
+        UPDI::stinc_b(JTAG2::packet.body[current_byte_index++]);
+        for (uint8_t i = bytes_remaining; i; i--) {
+          UPDI_io::put(JTAG2::packet.body[current_byte_index++]);
+          UPDI_io::get();
+        }
+      } else { //word write
+        int8_t words_remaining= (length >> 1)-1;
+        UPDI::stptr_l(address);
+#ifndef NO_ACK_WRITE
+        uint16_t firstword=JTAG2::packet.body[current_byte_index]|(JTAG2::packet.body[current_byte_index+1] << 8);
+        current_byte_index+=2;
+        UPDI::rep(words_remaining);
+        UPDI::stinc_w(firstword);
+        for (uint8_t i = words_remaining;i;i--) {
+          UPDI_io::put(JTAG2::packet.body[current_byte_index++]);
+          UPDI_io::put(JTAG2::packet.body[current_byte_index++]);
+          UPDI_io::get();
+        }
+        if (length & 0x01) { //in case they send us odd-legnth write command...
+          UPDI::stinc_b(JTAG2::packet.body[current_byte_index++]);
+        }
+#else //writing without ACK
+        UPDI::stcs(UPDI::reg::Control_A, 0x0E);
+        UPDI::rep(words_remaining);
+        UPDI::stinc_b_b_noget(JTAG2::packet.body[current_byte_index],JTAG2::packet.body[current_byte_index+1]);
+        current_byte_index+=2;
+        for (uint8_t i = words_remaining;i;i--) {
+          UPDI_io::put(JTAG2::packet.body[current_byte_index++]);
+          UPDI_io::put(JTAG2::packet.body[current_byte_index++]);
+        }
+        if (length & 0x01) { //in case they send us odd-legnth write command...
+          UPDI::stinc_b_noget(JTAG2::packet.body[current_byte_index++]);
+        }
+        UPDI::stcs(UPDI::reg::Control_A, 0x06);
+#endif
+      }
+    }
+    //now the data has been written, so reset the command...
+    uint8_t stat = UPDI::lds_b(NVM_v2::NVM_base + NVM_v2::STATUS);
+    if (stat > 3) {
+      uint8_t cmd=UPDI::lds_b(NVM_v2::NVM_base + NVM_v2::CTRLA);
+      #if defined(DEBUG_ON)
+      DBG::debug('f',stat,cmd,0);
+      #endif
+      UPDI::sts_b(NVM_v2::NVM_base + NVM_v2::STATUS, 0);
+    }
+    //wait until operation completed
+    NVM_v2::wait<false>();
+
+    NVM_v2::command<false>(NVM_v2::NOOP);
+  }
+
+  /*
+    void NVM_v2_word_write_flash(uint32_t address, uint16_t length){
+    uint16_t current_byte_index = 10;
+    if (length == 2){
+      NVM_v2::wait<false>();
+      NVM_v2::command<false>(NVM_v2::FLWR);
+      // write to flash
+      UPDI::sts_w_l(address,JTAG2::packet.body[current_byte_index]|(((uint16_t)JTAG2::packet.body[current_byte_index+1])<<8));
+      NVM_v2::command<false>(NVM_v2::NOOP);
+    } else {
+      uint8_t words_remaining = (length-2)>>1;
+      startDebug();
+      putDebug(0x6A);
+      putDebug(address & 0xFF);
+      putDebug((address >> 8) & 0xFF);
+      putDebug((address >> 16) & 0xFF);
+      putDebug(0xA0);
+      putDebug(words_remaining);
+      //wait until previous operation completed, if any
+      NVM_v2::wait<false>();
+      //set the write enable command
+      NVM_v2::command<false>(NVM_v2::FLWR);
+          // Set UPDI pointer to address
+
+      UPDI::stptr_l(address);
+      UPDI::rep(words_remaining);
+      uint16_t wordtowrite=JTAG2::packet.body[current_byte_index++];
+      wordtowrite+=JTAG2::packet.body[current_byte_index++]<<8;
+      UPDI::stinc_w(wordtowrite);
+      for (uint8_t i = words_remaining; i; i--) {
+        UPDI_io::put(JTAG2::packet.body[current_byte_index++]);
+        UPDI_io::put(JTAG2::packet.body[current_byte_index++]);
+        UPDI_io::get();
+      }
+      putDebug(current_byte_index & 0xFF);
+      putDebug((current_byte_index >> 8));
+      endDebug();
+      NVM_v2::command<false>(NVM_v2::NOOP);
+    }
+    }
+  */
+  void NVM_buffered_write(const uint16_t address, const uint16_t length, const uint8_t buff_size, const uint8_t write_cmnd) {
+    uint8_t current_byte_index = 10;          /* Index of the first byte to send inside the JTAG2 command body */
+    uint16_t bytes_remaining = length;          /* number of bytes to write */
+
+    // Sends a block of bytes from the command body to memory, using the UPDI interface
+    // On entry, the UPDI pointer must already point to the desired address
+    // On exit, the UPDI pointer points to the next byte after the last one written
+    // Returns updated index into the command body, pointing to the first unsent byte.
+    auto updi_send_block = [] (uint8_t count, uint8_t index) {
+      count--;
+      NVM::wait<true>();
+#ifndef NO_ACK_WRITE
+      UPDI::rep(count);
+      UPDI::stinc_b(JTAG2::packet.body[index]);
+      for (uint8_t i = count; i; i--) {
+        UPDI_io::put(JTAG2::packet.body[++index]);
+        UPDI_io::get();
+      }
+#else
+      UPDI::stcs(UPDI::reg::Control_A, 0x0E);
+      UPDI::rep(count);
+      UPDI::stinc_b_noget(JTAG2::packet.body[index]);
+      for (uint8_t i = count; i; i--) {
+        UPDI_io::put(JTAG2::packet.body[++index]);
+      }
+      UPDI::stcs(UPDI::reg::Control_A, 0x06);
+#endif
+      return ++index;
+    };
+
+    // Setup UPDI pointer for block transfer
+    UPDI::stptr_w(address);
+    /* Check address alignment, calculate number of unaligned bytes to send */
+    uint8_t unaligned_bytes = (-address & (buff_size - 1));
+    if (unaligned_bytes > bytes_remaining) unaligned_bytes = bytes_remaining;
+    /* If there are unaligned bytes, they must be sent first */
+    if (unaligned_bytes) {
+      // Send unaligned block
+      current_byte_index = updi_send_block(unaligned_bytes, current_byte_index);
+      bytes_remaining -= unaligned_bytes;
+      NVM::command<true>(write_cmnd);
+    }
+    while (bytes_remaining) {
+      /* Send a buff_size amount of bytes */
+      if (bytes_remaining >= buff_size) {
+        current_byte_index = updi_send_block(buff_size, current_byte_index);
+        bytes_remaining -= buff_size;
+      }
+      /* Send a NumBytes amount of bytes */
+      else {
+        current_byte_index = updi_send_block(bytes_remaining, current_byte_index);
+        bytes_remaining = 0;
+      }
+      NVM::command<true>(write_cmnd);
+    }
+  }
 }

--- a/source/JTAG2.h
+++ b/source/JTAG2.h
@@ -3,7 +3,7 @@
  *
  * Created: 12-11-2017 11:10:31
  *  Author: JMR_2
- */ 
+ */
 
 
 #ifndef JTAG2_H_
@@ -12,7 +12,7 @@
 #include "sys.h"
 
 namespace JTAG2 {
-	
+
 	// *** Parameter IDs ***
 	enum parameter {
 		PARAM_HW_VER				= 0x01,
@@ -33,18 +33,7 @@ namespace JTAG2 {
 		baud_115200,
 		baud_14400
 	};
-	
-	// *** valid values for PARAM_EMU_MODE_VAL
-	enum emul_mode {
-		EMULATOR_MODE_DEBUGWIRE,
-		EMULATOR_MODE_JTAG_MEGA,
-		EMULATOR_MODE_UNKNOWN,				// default according to JTAGICE MkII protocol
-		EMULATOR_MODE_SPI,
-		EMULATOR_MODE_JTAG_AVR32,
-		EMULATOR_MODE_JTAG_XMEGA,			// default for jtag2updi
-		EMULATOR_MODE_PDI
-	};
-	
+
 	// *** Parameter Values ***
 	constexpr uint8_t PARAM_HW_VER_M_VAL			= 0x01;
 	constexpr uint8_t PARAM_HW_VER_S_VAL			= 0x01;
@@ -52,9 +41,10 @@ namespace JTAG2 {
 	constexpr uint8_t PARAM_FW_VER_M_MAJ_VAL		= 0x06;
 	constexpr uint8_t PARAM_FW_VER_S_MIN_VAL		= 0x00;
 	constexpr uint8_t PARAM_FW_VER_S_MAJ_VAL		= 0x06;
-	extern emul_mode PARAM_EMU_MODE_VAL;
+	extern uint8_t PARAM_EMU_MODE_VAL;
+	extern uint8_t ConnectedTo;
 	extern baud_rate PARAM_BAUD_RATE_VAL;
-	constexpr uint16_t PARAM_VTARGET_VAL			= 5000;	
+	constexpr uint16_t PARAM_VTARGET_VAL			= 5000;
 
 	// *** General command constants ***
 	enum cmnd {
@@ -93,7 +83,7 @@ namespace JTAG2 {
 		RSP_DEBUGWIRE_SYNC_FAILED	= 0xAC,
 		RSP_ILLEGAL_POWER_STATE		= 0xAD
 	};
-	
+
 	// *** memory types for CMND_{READ,WRITE}_MEMORY ***
 	enum mem_type {
 		MTYPE_IO_SHADOW				= 0x30,		// cached IO registers?
@@ -112,12 +102,12 @@ namespace JTAG2 {
 		MTYPE_BOOT_FLASH			= 0xc1,		// xmega boot flash
 		MTYPE_EEPROM_XMEGA			= 0xc4,		// xmega EEPROM in debug mode
 		MTYPE_USERSIG				= 0xc5,		// xmega user signature
-		MTYPE_PRODSIG				= 0xc6		// xmega production signature	
+		MTYPE_PRODSIG				= 0xc6		// xmega production signature
 	};
-	
-	// *** STK500 packet *** 
+
+	// *** STK500 packet ***
 	constexpr uint8_t MESSAGE_START = 0x1B;
-	constexpr int MAX_BODY_SIZE = 450;				// Note: should not be reduced to less than 300 bytes.
+	constexpr int MAX_BODY_SIZE = 700;				// Note: should not be reduced to less than 300 bytes.
 	union packet_t {
 		uint8_t raw[6 + MAX_BODY_SIZE];
 		struct {
@@ -134,11 +124,11 @@ namespace JTAG2 {
 		};
 	} extern packet;
 	constexpr uint8_t TOKEN = 0x0E;
-	
+
 	// *** Parameter initialization ***
 	void init();
 
-	// *** Packet functions *** 
+	// *** Packet functions ***
 	bool receive();
 	void answer();
 	void delay_exec();
@@ -155,6 +145,7 @@ namespace JTAG2 {
 	// *** ISP command functions ***
 	void enter_progmode();
 	void leave_progmode();
+	void go();
 	void read_signature();
 	void read_mem();
 	void write_mem();

--- a/source/NVM_v2.h
+++ b/source/NVM_v2.h
@@ -1,0 +1,87 @@
+/*
+ * NVM_v2.h
+ *
+ * Created: 15-12-2017 10:59:53
+ *  Author: JMR_2
+ */
+
+
+#ifndef NVM_V2_H_
+#define NVM_V2_H_
+
+#include <stdint.h>
+#include "UPDI_lo_lvl.h"
+
+namespace NVM_v2 {
+  // *** Base Addresses ***
+
+  enum base {
+    NVM_base    = 0x1000,   /* Base address of the NVM controller */
+    Sig_base    = 0x1100,   /* Base address of the signature */
+    Fuse_base   = 0x1050,   /* Base address of the fuses */
+    User_base   = 0x1080,   /* Base address of the User Row EEPROM */
+    EEPROM_base = 0x1400    /* Base address of the main EEPROM */
+  };
+  // *** NVM Registers (offsets from NVN_base are enum default values) ***
+  enum reg {
+    CTRLA,
+    CTRLB,
+    STATUS,
+    INTCTRL,
+    INTFLAGS,
+    Reg_5,
+    DATA_lo,
+    DATA_hi,
+    ADDR_lo,
+    ADDR_hi,
+    ADDR_ext
+  };
+
+  // *** NVM Commands (write to CTRLA to execute) ***
+  enum cmnd {
+    NOCMD       = 0x00,    /* No command */
+    NOOP        = 0x01,    /* No operation */
+    FLWR        = 0x02,    /* Flash Write Enable */
+    FLPER       = 0x08,    /* Flash Page Erase Enable */
+    FLMPER2     = 0x09,    /* Flash 2-page Erase Enable */
+    FLMPER4     = 0x0A,    /* Flash 4-page Erase Enable */
+    FLMPER8     = 0x0B,    /* Flash 8-page Erase Enable */
+    FLMPER16    = 0x0C,    /* Flash 16-page Erase Enable */
+    FLMPER32    = 0x0D,    /* Flash 32-page Erase Enable */
+    EEWR        = 0x12,    /* EEPROM Write Enable */
+    EEERWR      = 0x13,    /* EEPROM Erase and Write Enable */
+    EEBER       = 0x18,    /* EEPROM Byte Erase Enable */
+    EEMBER2     = 0x19,    /* EEPROM 2-byte Erase Enable */
+    EEMBER4     = 0x1A,    /* EEPROM 4-byte Erase Enable */
+    EEMBER8     = 0x1B,    /* EEPROM 8-byte Erase Enable */
+    EEMBER16    = 0x1C,    /* EEPROM 16-byte Erase Enable */
+    EEMBER32    = 0x1D,    /* EEPROM 32-byte Erase Enable */
+    CHER        = 0x20,    /* Erase Flash and EEPROM. EEPROM is skipped if EESAVE fuse is set. (UPDI access only.) */
+    EECHER      = 0x30    /* Erase EEPROM */
+  };
+  // *** NVM Functions ***
+  template <bool preserve_ptr>
+  void command (uint8_t cmd) {
+    uint32_t temp;
+    /* preserve UPDI pointer if requested */
+    if (preserve_ptr) temp = UPDI::ldptr_l();
+    /* Execute NVM command */
+    UPDI::sts_b(NVM_v2::NVM_base + NVM_v2::CTRLA, cmd);
+    /* restore UPDI pointer if requested */
+    if (preserve_ptr) UPDI::stptr_l(temp);
+  }
+
+  template <bool preserve_ptr>
+  void wait () {
+    uint32_t temp;
+    /* preserve UPDI pointer if requested */
+    if (preserve_ptr) temp = UPDI::ldptr_l();
+    /* Wait while NVM is busy from previous operations */
+    while (UPDI::lds_b(NVM_v2::NVM_base + NVM_v2::STATUS) & 0x03);
+    /* restore UPDI pointer if requested */
+    if (preserve_ptr) UPDI::stptr_l(temp);
+  }
+
+}
+
+#endif /* NVM_H_ */

--- a/source/NVM_v2.h
+++ b/source/NVM_v2.h
@@ -66,7 +66,7 @@ namespace NVM_v2 {
     /* preserve UPDI pointer if requested */
     if (preserve_ptr) temp = UPDI::ldptr_l();
     /* Execute NVM command */
-    UPDI::sts_b(NVM_v2::NVM_base + NVM_v2::CTRLA, cmd);
+    UPDI::sts_b_l(NVM_v2::NVM_base + NVM_v2::CTRLA, cmd);
     /* restore UPDI pointer if requested */
     if (preserve_ptr) UPDI::stptr_l(temp);
   }
@@ -77,7 +77,7 @@ namespace NVM_v2 {
     /* preserve UPDI pointer if requested */
     if (preserve_ptr) temp = UPDI::ldptr_l();
     /* Wait while NVM is busy from previous operations */
-    while (UPDI::lds_b(NVM_v2::NVM_base + NVM_v2::STATUS) & 0x03);
+    while (UPDI::lds_b_l(NVM_v2::NVM_base + NVM_v2::STATUS) & 0x03);
     /* restore UPDI pointer if requested */
     if (preserve_ptr) UPDI::stptr_l(temp);
   }

--- a/source/UPDI_hi_lvl.cpp
+++ b/source/UPDI_hi_lvl.cpp
@@ -3,18 +3,99 @@
  *
  * Created: 15-02-2018 23:08:39
  *  Author: JMR_2
- */ 
+ */
 
 #include "UPDI_hi_lvl.h"
+#include "dbg.h"
 
-void UPDI::CPU_reset(){
-	// Request reset
+bool UPDI::CPU_reset(){
+  #if defined(DEBUG_RESET)
+    DBG::updi_reset();
+  #endif
+
+  // Request reset
 	UPDI::stcs(UPDI::reg::ASI_Reset_Request, UPDI::RESET_ON);
 	// Release reset (System remains in reset state until released)
 	UPDI::stcs(UPDI::reg::ASI_Reset_Request, UPDI::RESET_OFF);
-	
+
 	// Wait for the reset process to end.
 	// Either NVMPROG, UROWPROG or BOOTDONE bit will be set in the ASI_SYS_STATUS UPDI register.
 	// This indicates reset is complete.
-	while ( UPDI::CPU_mode<0x0E>() == 0 );
+  #ifndef DISABLE_TARGET_TIMEOUT
+    uint8_t timeoutcount=0;
+    while ( UPDI::CPU_mode<0x0E>() == 0 && timeoutcount<2) //if it takes 200ms to come back after we release reset... it's never going to!
+    {
+      if (SYS::checkTimeouts() & WAIT_FOR_TARGET) {
+        SYS::clearTimeouts();
+        timeoutcount++;
+      }
+    }
+  #else
+    while ( UPDI::CPU_mode<0x0E>() == 0 );
+  #endif
+  
+  #if defined(DEBUG_RESET) && !defined(DEBUG_LDCS)
+  //if LDCS is defined, it will pick this up
+  #ifndef DISABLE_TARGET_TIMEOUT
+  if(timeoutcount) {
+    DBG::debug('T',timeoutcount);
+  }
+  #endif
+  DBG::updi_post_reset(UPDI::CPU_mode<0xFF>());
+  #endif
+  #ifndef DISABLE_TARGET_TIMEOUT
+    return (timeoutcount<2); //if we didn't timeout and give up trying to bring it out of reset, return true
+  #else
+    return 1;
+  #endif
+}
+void UPDI::CPU_reset_on(){
+  #if defined(DEBUG_RESET)
+    DBG::updi_reset_on();
+  #endif
+
+  // Request reset
+  UPDI::stcs(UPDI::reg::ASI_Reset_Request, UPDI::RESET_ON);
+  // System remains in reset state until released
+
+}
+
+bool UPDI::CPU_reset_off(){
+  #if defined(DEBUG_RESET)
+    DBG::updi_reset_off();
+  #endif
+
+  // Release reset (System remains in reset state until released)
+  UPDI::stcs(UPDI::reg::ASI_Reset_Request, UPDI::RESET_OFF);
+
+  // Wait for the reset process to end.
+  // Either NVMPROG, UROWPROG or BOOTDONE bit will be set in the ASI_SYS_STATUS UPDI register.
+  // This indicates reset is complete.
+  #ifndef DISABLE_TARGET_TIMEOUT
+    uint8_t timeoutcount=0;
+    while ( UPDI::CPU_mode<0x0E>() == 0 && timeoutcount<2) //if it takes 200ms to come back after we release reset... it's never going to!
+    {
+      if (SYS::checkTimeouts() & WAIT_FOR_TARGET) {
+        SYS::clearTimeouts();
+        timeoutcount++;
+      }
+    }
+  #else
+    while ( UPDI::CPU_mode<0x0E>() == 0 );
+  #endif
+  
+  #if defined(DEBUG_RESET) && !defined(DEBUG_LDCS)
+  //if LDCS is defined, it will pick this up
+  #ifndef DISABLE_TARGET_TIMEOUT
+  if(timeoutcount) {
+    DBG::debug('T',timeoutcount);
+  }
+  #endif
+  DBG::updi_post_reset(UPDI::CPU_mode<0xFF>());
+  #endif
+  #ifndef DISABLE_TARGET_TIMEOUT
+    return (timeoutcount<2); //if we didn't timeout and give up trying to bring it out of reset, return true
+  #else
+    return 1;
+  #endif
 }

--- a/source/UPDI_hi_lvl.h
+++ b/source/UPDI_hi_lvl.h
@@ -17,7 +17,9 @@ namespace UPDI {
 	constexpr uint8_t RESET_OFF = 0x00;
 
 	// Function prototypes
-	void CPU_reset();
+	bool CPU_reset();
+  void CPU_reset_on();
+  bool CPU_reset_off();
 
 	// returns the current CPU mode, optionally a mask can be applied to ignore "don't care" status bits
 	template <uint8_t mask = 0xFF>

--- a/source/UPDI_hi_lvl.h
+++ b/source/UPDI_hi_lvl.h
@@ -3,7 +3,7 @@
  *
  * Created: 15-02-2018 23:12:54
  *  Author: JMR_2
- */ 
+ */
 
 
 #ifndef UPDI_HI_LVL_H_
@@ -16,19 +16,14 @@ namespace UPDI {
 	constexpr uint8_t RESET_ON = 0x59;
 	constexpr uint8_t RESET_OFF = 0x00;
 
-	// Function prototypes		
+	// Function prototypes
 	void CPU_reset();
-	
+
 	// returns the current CPU mode, optionally a mask can be applied to ignore "don't care" status bits
 	template <uint8_t mask = 0xFF>
 	uint8_t CPU_mode() {
-		uint8_t mode = UPDI::lcds(UPDI::reg::ASI_System_Status);
-		return mode & mask;	
-	}
-	
-	// Disables the UPDI unit
-	inline void disable() {
-		UPDI::stcs(UPDI::reg::Control_B, 4);
+		uint8_t mode = UPDI::ldcs(UPDI::reg::ASI_System_Status);
+		return mode & mask;
 	}
 }
 

--- a/source/UPDI_lo_lvl.cpp
+++ b/source/UPDI_lo_lvl.cpp
@@ -67,9 +67,6 @@ REP - Repeat Command
 
 
 void UPDI::rep(uint8_t repeats) {
-#if (defined(DEBUG_UPDI) && (defined(DEBUG_LD)||defined(DEBUG_ST)))
-  UPDI::burst_next=1;
-#endif
 #ifdef DEBUG_REP
   DBG::updi_rep(repeats);
 #endif

--- a/source/UPDI_lo_lvl.cpp
+++ b/source/UPDI_lo_lvl.cpp
@@ -1,213 +1,371 @@
 /*
- * UPDI_cmd.cpp
- *
- * Created: 23-11-2017 22:48:36
- *  Author: JMR_2
- */ 
+   UPDI_cmd.cpp
+
+   Created: 23-11-2017 22:48:36
+    Author: JMR_2
+*/
 
 // Includes
 #include "UPDI_lo_lvl.h"
+#include "sys.h"
+#include "dbg.h"
 
-// Special optimization options
-// Unused r/w I/O registers residing in the space addressable by in/out instructions
-// can be used as temporary registers to save a few bytes/cycles.
-// Warning: MCU specific!!!
-//#define TEMP0 EEARL
-//#define TEMP1 GPIOR0
-//#define TEMP2 GPIOR1
+// _l  versions have long (24-bit) address poimter
+// otherwisem, address pointer is 16-bit
+
+
 
 // Keys
 FLASH<uint8_t> UPDI::Chip_Erase[8] {0x65, 0x73, 0x61, 0x72, 0x45, 0x4D, 0x56, 0x4E};
 FLASH<uint8_t> UPDI::NVM_Prog[8] {0x20, 0x67, 0x6F, 0x72, 0x50, 0x4D, 0x56, 0x4E};
 FLASH<uint8_t> UPDI::UserRow_Write[8] {0x65, 0x74, 0x26, 0x73, 0x55, 0x4D, 0x56, 0x4E};
 
-// Functions
-void UPDI::rep(uint8_t repeats) {
-#	ifdef TEMP0
-	TEMP0 = repeats;
-#	endif
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0xA0);
-#	ifdef TEMP0
-	UPDI_io::put(TEMP0);
-#	else
-	UPDI_io::put(repeats);
-#	endif
-}
+/*
+
+STCS - Store to Control Register
+
+*/
+
 
 void UPDI::stcs(reg r, uint8_t data) {
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0xC0 + r);
-	UPDI_io::put(data);
+#ifdef DEBUG_STCS
+  DBG::updi_stcs(r,data);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0xC0 + r);
+  UPDI_io::put(data);
 }
 
-uint8_t UPDI::lcds(reg r) {
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x80 + r);
-	return UPDI_io::get();
+
+/*
+
+LDCS - Load Control Register
+
+*/
+
+
+uint8_t UPDI::ldcs(reg r) {
+#ifdef DEBUG_LDCS
+  DBG::updi_ldcs(r);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x80 + r);
+#ifdef DEBUG_LDCS
+  uint8_t resp= UPDI_io::get();
+  DBG::updi_res(resp);
+  return resp;
+#else
+  return UPDI_io::get();
+#endif
 }
 
-uint8_t UPDI::lds_b(uint16_t address){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x04);
-	UPDI_io::put(address & 0xFF);
-	UPDI_io::put(address >> 8);	
-	return UPDI_io::get();
+/*
+
+REP - Repeat Command
+
+*/
+
+
+void UPDI::rep(uint8_t repeats) {
+#if (defined(DEBUG_UPDI) && (defined(DEBUG_LD)||defined(DEBUG_ST)))
+  UPDI::burst_next=1;
+#endif
+#ifdef DEBUG_REP
+  DBG::updi_rep(repeats);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0xA0);
+  UPDI_io::put(repeats);
 }
 
-uint16_t UPDI::lds_w(uint16_t address){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x05);
-	UPDI_io::put(address & 0xFF);
-	UPDI_io::put(address >> 8);
-	return UPDI_io::get() | (UPDI_io::get() << 8);
+/*
+
+LDS - Load with Direct Addressing
+
+*/
+
+uint8_t UPDI::lds_b(uint16_t address) {
+#ifdef DEBUG_LDS
+  DBG::updi_lds(address);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x04);
+  UPDI_io::put(address & 0xFF);
+  UPDI_io::put(address >> 8);
+#ifdef DEBUG_LDS
+  uint8_t resp= UPDI_io::get();
+  DBG::updi_res(resp);
+  return resp;
+#else
+  return UPDI_io::get();
+#endif
 }
 
-void UPDI::sts_b(uint16_t address, uint8_t data){
-#	ifdef TEMP0
-	TEMP0 = data;
-#	endif
-#	ifdef TEMP1
-	TEMP1 = address & 0xFF;
-#	endif
-#	ifdef TEMP2
-	TEMP2 = address >> 8;
-#	endif
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x44);
-#	ifdef TEMP1
-	UPDI_io::put(TEMP1);
-#	else
-	UPDI_io::put(address & 0xFF);
-#	endif
-#	ifdef TEMP2
-	UPDI_io::put(TEMP2);
-#	else
-	UPDI_io::put(address >> 8);
-#	endif
-	UPDI_io::get();
-#	ifdef TEMP0
-	UPDI_io::put(TEMP0);
-#	else
-	UPDI_io::put(data);
-#	endif
-	UPDI_io::get();
+uint8_t UPDI::lds_b_l(uint32_t address) {
+#ifdef DEBUG_LDS
+  DBG::updi_lds(address);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x08);
+  UPDI_io::put(address);
+  UPDI_io::put(address >> 8);
+  UPDI_io::put(address >> 16);
+#ifdef DEBUG_LDS
+  uint8_t resp= UPDI_io::get();
+  DBG::updi_res(resp);
+  return resp;
+#else
+  return UPDI_io::get();
+#endif
 }
 
-void UPDI::sts_w(uint16_t address, uint16_t data){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x45);
-	UPDI_io::put(address & 0xFF);
-	UPDI_io::put(address >> 8);
-	UPDI_io::get();
-	UPDI_io::put(data & 0xFF);
-	UPDI_io::put(data >> 8);
-	UPDI_io::get();
+uint16_t UPDI::lds_w(uint16_t address) {
+#ifdef DEBUG_LDS
+  DBG::updi_lds(address);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x05);
+  UPDI_io::put(address);
+  UPDI_io::put(address >> 8);
+#ifdef DEBUG_LDS
+  uint16_t resp= UPDI_io::get()|(UPDI_io::get() << 8);
+  DBG::updi_res(resp);
+  return resp;
+#else
+  return UPDI_io::get() | (UPDI_io::get() << 8);
+#endif
 }
 
-uint8_t UPDI::ldptr_b(){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x28);
-	return UPDI_io::get();
+uint16_t UPDI::lds_w_l(uint32_t address) {
+#ifdef DEBUG_LDS
+  DBG::updi_lds(address);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x09);
+  UPDI_io::put(address);
+  UPDI_io::put(address >> 8);
+  UPDI_io::put(address >> 16);
+#ifdef DEBUG_LDS
+  uint16_t resp= UPDI_io::get()|(UPDI_io::get() << 8);
+  DBG::updi_res(resp);
+  return resp;
+#else
+  return UPDI_io::get() | (UPDI_io::get() << 8);
+#endif
 }
 
-uint16_t UPDI::ldptr_w(){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x29);
-#	ifdef TEMP0
-	TEMP0 = UPDI_io::get();
-	return (UPDI_io::get() << 8) | TEMP0;
-#	else
-	return UPDI_io::get() | (UPDI_io::get() << 8);
-#	endif
+
+/*
+
+STS - Byte oriented Store with Direct Addressing
+
+*/
+
+
+
+void UPDI::sts_b(uint16_t address, uint8_t data) {
+#ifdef DEBUG_STS
+  DBG::updi_sts(address,data);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x44);
+  UPDI_io::put(address & 0xFF);
+  UPDI_io::put(address >> 8);
+  UPDI_io::get();
+  UPDI_io::put(data);
+  UPDI_io::get();
 }
 
-uint8_t UPDI::ld_b(){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x20);
-	return UPDI_io::get();
+
+void UPDI::sts_b_l(uint32_t address, uint8_t data) {
+#ifdef DEBUG_STS
+  DBG::updi_sts(address,data);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x48);
+  UPDI_io::put(address & 0xFF);
+  UPDI_io::put((address >> 8) & 0xFF);
+  UPDI_io::put((address >> 16) & 0xFF);
+  UPDI_io::get();
+  UPDI_io::put(data);
+  UPDI_io::get();
 }
 
-uint16_t UPDI::ld_w(){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x21);
-	return UPDI_io::get() | (UPDI_io::get() << 8);
+
+/*
+
+STS - Store with Direct Addressing
+
+*/
+
+void UPDI::sts_w(uint16_t address, uint16_t data) {
+#ifdef DEBUG_STS
+  DBG::updi_sts(address,data);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x45);
+  UPDI_io::put(address & 0xFF);
+  UPDI_io::put(address >> 8);
+  UPDI_io::get();
+  UPDI_io::put(data & 0xFF);
+  UPDI_io::put(data >> 8);
+  UPDI_io::get();
 }
 
-uint8_t UPDI::ldinc_b(){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x24);
-	return UPDI_io::get();
+void UPDI::sts_w_l(uint32_t address, uint16_t data) {
+#ifdef DEBUG_STS
+  DBG::updi_sts(address,data);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x49);
+  UPDI_io::put(address & 0xFF);
+  UPDI_io::put((address >> 8) & 0xFF);
+  UPDI_io::put((address >> 16) & 0xFF);
+  UPDI_io::get();
+  UPDI_io::put(data & 0xFF);
+  UPDI_io::put(data >> 8);
+  UPDI_io::get();
 }
 
-uint16_t UPDI::ldinc_w(){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x25);
-	return UPDI_io::get() | (UPDI_io::get() << 8);
+/*
+
+STPTR - Set pointer for indirect addressing
+
+*/
+
+
+void UPDI::stptr_b(uint8_t address) {
+  // No debug code here - byte-addressed STPTR is never actually used!
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x68);
+  UPDI_io::put(address);
+  UPDI_io::get();
 }
 
-void UPDI::stptr_b(uint8_t address){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x68);
-	UPDI_io::put(address);
-	UPDI_io::get();
+void UPDI::stptr_w(uint16_t address) {
+#ifdef DEBUG_STPTR
+  DBG::updi_st_ptr_w(address);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x69);
+  UPDI_io::put(address & 0xFF);
+  UPDI_io::put(address >> 8);
+  UPDI_io::get();
 }
 
-void UPDI::stptr_w(uint16_t address){
-#	ifdef TEMP0
-	TEMP0 = address & 0xFF;
-#	endif
-#	ifdef TEMP1
-	TEMP1 = address >> 8;
-#	endif
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x69);
-#	ifdef TEMP0
-	UPDI_io::put(TEMP0);
-#	else
-	UPDI_io::put(address & 0xFF);
-#	endif
-#	ifdef TEMP1
-	UPDI_io::put(TEMP1);
-#	else
-	UPDI_io::put(address >> 8);
-#	endif
-	UPDI_io::get();
+void UPDI::stptr_l(uint32_t address) {
+#ifdef DEBUG_STPTR
+  DBG::updi_st_ptr_l(address);
+#endif
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x6A);
+  UPDI_io::put(address & 0xFF);
+  UPDI_io::put((address >> 8) & 0xFF);
+  UPDI_io::put((address >> 16) & 0xFF);
+  UPDI_io::get();
 }
 
-void UPDI::st_b(uint8_t data){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x60);
-	UPDI_io::put(data);
-	UPDI_io::get();
+/*
+
+LDPTR - Load pointer for indirect addressing
+
+*/
+
+
+uint8_t UPDI::ldptr_b() {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x28);
+  return UPDI_io::get();
 }
 
-void UPDI::st_w(uint16_t data){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x61);
-	UPDI_io::put(data & 0xFF);
-	UPDI_io::put(data >> 8);
-	UPDI_io::get();
+uint16_t UPDI::ldptr_w() {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x29);
+  return UPDI_io::get() | (UPDI_io::get() << 8);
 }
 
-void UPDI::stinc_b(uint8_t data){
-#	ifdef TEMP0
-	TEMP0 = data;
-#	endif
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x64);
-#	ifdef TEMP0
-	UPDI_io::put(TEMP0);
-#	else
-	UPDI_io::put(data);
-#	endif
-	UPDI_io::get();
+uint32_t UPDI::ldptr_l() {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x2A);
+  return UPDI_io::get() | (UPDI_io::get() << 8) | (((uint32_t)UPDI_io::get()) << 16);
+}
+uint8_t UPDI::ld_b() {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x20);
+  return UPDI_io::get();
 }
 
-void UPDI::stinc_w(uint16_t data){
-	UPDI_io::put(UPDI::SYNCH);
-	UPDI_io::put(0x65);
-	UPDI_io::put(data & 0xFF);
-	UPDI_io::put(data >> 8);
-	UPDI_io::get();
+uint16_t UPDI::ld_w() {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x21);
+  return UPDI_io::get() | (UPDI_io::get() << 8);
+}
+
+uint8_t UPDI::ldinc_b() {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x24);
+  return UPDI_io::get();
+}
+
+uint16_t UPDI::ldinc_w() {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x25);
+  return UPDI_io::get() | (UPDI_io::get() << 8);
+}
+
+
+void UPDI::st_b(uint8_t data) {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x60);
+  UPDI_io::put(data);
+  UPDI_io::get();
+}
+
+void UPDI::st_w(uint16_t data) {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x61);
+  UPDI_io::put(data & 0xFF);
+  UPDI_io::put(data >> 8);
+  UPDI_io::get();
+}
+
+void UPDI::stinc_b(uint8_t data) {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x64);
+  UPDI_io::put(data);
+  UPDI_io::get();
+}
+
+void UPDI::stinc_w(uint16_t data) {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x65);
+  UPDI_io::put(data & 0xFF);
+  UPDI_io::put(data >> 8);
+  UPDI_io::get();
+}
+
+/*
+
+STINC noget variants
+For use when the RSD bit is set in control register A
+This is done to improve performance when doing busst writes
+
+stinc_b_noget is copy of stinc_b without the get()
+
+stinc_b_b_noget is copy of stinc_w without the get(), and with data expressed as two
+bytes instead of a word, since this is more convenient in the single place that it is called from
+
+*/
+
+void UPDI::stinc_b_noget(uint8_t data) {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x64);
+  UPDI_io::put(data);
+}
+
+void UPDI::stinc_b_b_noget(uint8_t data0, uint8_t data1) {
+  UPDI_io::put(UPDI::SYNCH);
+  UPDI_io::put(0x65);
+  UPDI_io::put(data0);
+  UPDI_io::put(data1);
 }

--- a/source/UPDI_lo_lvl.h
+++ b/source/UPDI_lo_lvl.h
@@ -14,15 +14,6 @@
 #include "updi_io.h"
 #include "dbg.h"
 
-#if defined(DEBUG_ON)
-//#define DEBUG_STCS
-//#define DEBUG_LDCS
-//#define DEBUG_REP
-//#define DEBUG_STS
-//#define DEBUG_STPTR
-//#define DEBUG_LDS
-//#define DEBUG_KEY
-#endif
 
 namespace UPDI {
 	// UPDI registers
@@ -43,9 +34,6 @@ namespace UPDI {
 	extern FLASH<uint8_t> NVM_Prog[8];
 	extern FLASH<uint8_t> UserRow_Write[8];
 
-  #ifdef DEBUG_UPDI
-	uint8_t burst_next=0;
-  #endif
 
 	// Function prototypes
 	void rep(uint8_t);

--- a/source/UPDI_lo_lvl.h
+++ b/source/UPDI_lo_lvl.h
@@ -3,14 +3,26 @@
  *
  * Created: 23-11-2017 22:46:11
  *  Author: JMR_2
- */ 
+ */
 
 
 #ifndef UPDI_LO_LVL_H_
 #define UPDI_LO_LVL_H_
 
 #include "sys.h"
+#include "dbg.h"
 #include "updi_io.h"
+#include "dbg.h"
+
+#if defined(DEBUG_ON)
+//#define DEBUG_STCS
+//#define DEBUG_LDCS
+//#define DEBUG_REP
+//#define DEBUG_STS
+//#define DEBUG_STPTR
+//#define DEBUG_LDS
+//#define DEBUG_KEY
+#endif
 
 namespace UPDI {
 	// UPDI registers
@@ -21,31 +33,39 @@ namespace UPDI {
 		ASI_CRC_Status, Reg_13, Reg_14, Reg_15
 	};
 
-	
+
 	// Constant Expressions
 	constexpr uint8_t SYNCH = 0x55;
 	constexpr uint8_t ACK = 0x40;
-	
+
 	// Activation Keys
 	extern FLASH<uint8_t> Chip_Erase[8];
 	extern FLASH<uint8_t> NVM_Prog[8];
 	extern FLASH<uint8_t> UserRow_Write[8];
-	
+
+  #ifdef DEBUG_UPDI
+	uint8_t burst_next=0;
+  #endif
 
 	// Function prototypes
 	void rep(uint8_t);
-	
+
 	void stcs(reg, uint8_t);
-	uint8_t lcds(reg);
+	uint8_t ldcs(reg);
 
 	uint8_t lds_b(uint16_t);
 	uint16_t lds_w(uint16_t);
+	uint8_t lds_b_l(uint32_t);
+	uint16_t lds_w_l(uint32_t);
 
 	void sts_b(uint16_t address, uint8_t data); /* Store data at address */
 	void sts_w(uint16_t, uint16_t);
+	void sts_b_l(uint32_t, uint8_t);
+	void sts_w_l(uint32_t, uint16_t);
 
 	uint8_t ldptr_b();
 	uint16_t ldptr_w();
+	uint32_t ldptr_l();
 	uint8_t ld_b();
 	uint16_t ld_w();
 	uint8_t ldinc_b();
@@ -53,10 +73,14 @@ namespace UPDI {
 
 	void stptr_b(uint8_t);
 	void stptr_w(uint16_t);
+	void stptr_l(uint32_t);
+
 	void st_b(uint8_t);
 	void st_w(uint16_t);
 	void stinc_b(uint8_t);
 	void stinc_w(uint16_t);
+	void stinc_b_noget(uint8_t); //used only in NO_ACK_WRITE write routine
+	void stinc_b_b_noget(uint8_t,uint8_t); //used only NO_ACK_WRITE write routine
 
 	template <class T>
 	inline void write_key(T (& k)[8]) __attribute__(( optimize("no-tree-loop-optimize") ));
@@ -64,15 +88,21 @@ namespace UPDI {
 	// Function Templates
 	template <class T>
 	void write_key(T (& k)[8]) {
+    #ifdef DEBUG_KEY
+    DBG::updi_key();
+    #endif
 		UPDI_io::put(SYNCH);
 		UPDI_io::put(0xE0);
 		T* key_ptr = k;
 		for (uint8_t i = 8; i != 0; i--) {
+      #ifdef DEBUG_KEY
+      DBG::updi_res(*key_ptr);
+      #endif
 			UPDI_io::put(*key_ptr);
 			key_ptr++;
 		}
 	}
-	
+
 	template <uint16_t T>
 	void read_sib(uint8_t (& buffer)[T]) {
 		static_assert( (T == 8) || (T == 16), "read_sib(): argument must be a uint8_t[] with 8 or 16 elements" );

--- a/source/dbg.cpp
+++ b/source/dbg.cpp
@@ -1,0 +1,389 @@
+/*
+ * dbg.h
+ *
+ * Created:5/11/2020
+ *  Author: Spence Konde  (tindie.com/stores/drazzy)
+ * github.com/SpenceKonde
+ */
+
+#include <avr/io.h>
+#include <stdio.h>
+#include "dbg.h"
+#include "sys.h"
+
+#if defined(DEBUG_ON)
+
+void DBG::updi_st_ptr_l(uint32_t address) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("st_ptr ");
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(address>>16);
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteHex(address);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_st_ptr_w(uint16_t address) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("st_ptr ");
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(address);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+
+void DBG::updi_lds(uint32_t address) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("lds ");
+    DBG::debugWriteHex(address>>16);
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteHex(address);
+    DBG::debugWriteByte(' ');
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_lds(uint16_t address) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("lds ");
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteHex(address);
+    DBG::debugWriteByte(' ');
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_sts(uint32_t address, uint16_t data) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("sts ");
+    DBG::debugWriteHex(address>>16);
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteHex(address);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data>>8);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_sts(uint32_t address, uint8_t data) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("sts ");
+    DBG::debugWriteHex(address>>16);
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteHex(address);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_sts(uint16_t address, uint16_t data) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("sts ");
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteHex(address);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data>>8);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_sts(uint16_t address, uint8_t data) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("sts ");
+    DBG::debugWriteHex(address>>8);
+    DBG::debugWriteHex(address);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+
+void DBG::updi_ldcs(uint8_t command) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("ldcs ");
+    DBG::debugWriteHex(command);
+    DBG::debugWriteByte(' ');
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_stcs(uint8_t command, uint8_t data) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("stcs ");
+    DBG::debugWriteHex(command);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+
+void DBG::updi_rep(uint8_t reps) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("rep ");
+    DBG::debugWriteHex(reps);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_res(uint32_t data, uint8_t isaddr) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    if (isaddr) {
+      DBG::debugWriteHex(data>>16);
+      DBG::debugWriteHex(data>>8);
+      DBG::debugWriteHex(data);
+    } else {
+      DBG::debugWriteHex(data);
+      DBG::debugWriteByte(' ');
+      DBG::debugWriteHex(data>>8);
+      DBG::debugWriteByte(' ');
+      DBG::debugWriteHex(data>>16);
+    }
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_res(uint16_t data, uint8_t isaddr) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    if (isaddr) {
+      DBG::debugWriteHex(data>>8);
+      DBG::debugWriteHex(data);
+    } else {
+      DBG::debugWriteHex(data);
+      DBG::debugWriteByte(' ');
+      DBG::debugWriteHex(data>>8);
+    }
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_res(uint8_t data) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteHex(data);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_key(){
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("key ");
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::initDebug(void) {
+  #ifdef USE_SPIDEBUG
+    DDR(SPIPORT)|=1<<SCKPIN;
+    DDR(SPIPORT)|=1<<MOSIPIN;
+    DDR(SPIPORT)|=1<<SSPIN;
+    PORT(SPIPORT)|=1<<SSPIN;
+  #endif
+  #if defined XAVR
+    // Set clock speed to maximum (default 20MHz, or 16MHz set by fuse)
+    #if defined(USE_USARTDEBUG)
+      #if !defined(USE_EXTERNAL_OSCILLATOR)
+        #if (F_CPU==20000000UL) //this means we are on the 20MHz oscillator
+          #ifdef UARTBAUD3V
+            int8_t sigrow_val = SIGROW.OSC20ERR3V;
+          #else
+            int8_t sigrow_val = SIGROW.OSC20ERR5V;
+          #endif
+        #else //we are on 16MHz one
+          #ifdef UARTBAUD3V
+            int8_t sigrow_val = SIGROW.OSC16ERR3V;
+          #else
+            int8_t sigrow_val = SIGROW.OSC16ERR5V;
+          #endif
+        #endif
+        uint32_t baud_setting = ((8 * F_CPU) / BAUDRATE);
+        baud_setting *= (1024 + sigrow_val);
+        baud_setting += 512;
+        baud_setting /= 1024;
+      #else
+        uint32_t baud_setting = (((16 * F_CPU) / BAUDRATE) + 1) / 2;
+      #endif
+      DEBUGBAUDREG=(uint16_t)baud_setting;
+      DEBUG_USART.CTRLB = USART_RXMODE_CLK2X_gc | USART_TXEN_bm;
+      DDR(DEBUG_TX_PORT)|=1<<DEBUG_TX_PIN;
+      PORT(DEBUG_TX_PORT)|=1<<DEBUG_TX_PIN;
+    #elif defined(USE_SPIDEBUG)
+      SPIDEBUG.CTRLA=SPI_MASTER_bm|SPI_ENABLE_bm|((SPI_PRESC_gm|SPI_CLK2X_bm) & SPIPRESC);
+      SPIDEBUG.CTRLB=SPI_SSD_bm;
+    #endif
+  #else //not XAVR
+    #if defined(USE_SPIDEBUG)
+      DDR(SPIPORT)|=1<<SCKPIN;
+      DDR(SPIPORT)|=1<<MOSIPIN;
+      DDR(SPIPORT)|=1<<SSPIN;
+      PORT(SPIPORT)|=1<<SSPIN;
+      SPSR=(SPIPRESC&1); //set SPI2X if wanted
+      SPCR=(1<<MSTR) |(1<<SPE)| ((SPIPRESC>>1)&0x03);
+    #elif defined(USE_USARTDEBUG)
+      DEBUG_UCSRB=(1<<TXEN0);
+      DEBUGFLAGS=(1<<U2X0);
+    #endif
+  #endif
+}
+
+void DBG::debug(char prefix, uint8_t data0, uint8_t data1, uint8_t data2){
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteByte(prefix);
+    DBG::debugWriteHex(data0);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data1);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data2);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+void DBG::debug(char prefix, uint8_t data0, uint8_t data1){
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteByte(prefix);
+    DBG::debugWriteHex(data0);
+    DBG::debugWriteByte(' ');
+    DBG::debugWriteHex(data1);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+void DBG::debug(char prefix, uint8_t data0){
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteByte(prefix);
+    DBG::debugWriteHex(data0);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+
+void DBG::debug(const char *str, uint8_t newline) {
+  DBG::debug((const uint8_t *)str, strlen(str), newline);
+}
+void DBG::debug(const uint8_t *data, size_t datalen , uint8_t newline) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    if (newline) {
+      DBG::debugWriteByte(0x0D);
+      DBG::debugWriteByte(0x0A);
+    }
+    DBG::debugWriteBytes(data,datalen);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+void DBG::debugWriteStr(const char *str) {
+  DBG::debugWriteBytes((const uint8_t *)str, strlen(str));
+}
+void DBG::debugWriteBytes(const uint8_t *data, size_t datalen) {
+    while (datalen--) {
+      DBG::debugWriteByte(*data++);
+    }
+    
+}
+void DBG::debugWriteHex(uint8_t databyte) {
+  uint8_t b1=(databyte>>4)|'0';
+  uint8_t b2=(databyte&0x0F)|'0';
+  if (b1 > '9') b1+=7;
+  if (b2 > '9') b2+=7;
+  DBG::debugWriteByte(b1);
+  DBG::debugWriteByte(b2);
+}
+
+void DBG::debugWriteByte(uint8_t databyte) {
+  DEBUGDATA=databyte;
+  loop_until_bit_is_set(DEBUGFLAGS,DEBUGSENDNOW);
+}
+
+#endif

--- a/source/dbg.cpp
+++ b/source/dbg.cpp
@@ -256,10 +256,10 @@ void DBG::initDebug(void) {
     DDR(SPIPORT)|=1<<SSPIN;
     PORT(SPIPORT)|=1<<SSPIN;
   #endif
-  #if defined XAVR
+  #if defined(XAVR)
     // Set clock speed to maximum (default 20MHz, or 16MHz set by fuse)
     #if defined(USE_USARTDEBUG)
-      #if !defined(USE_EXTERNAL_OSCILLATOR)
+      #if !defined(USE_EXTERNAL_OSCILLATOR) && !defined(__AVR_DA__)
         #if (F_CPU==20000000UL) //this means we are on the 20MHz oscillator
           #ifdef UARTBAUD3V
             int8_t sigrow_val = SIGROW.OSC20ERR3V;
@@ -370,7 +370,7 @@ void DBG::debugWriteBytes(const uint8_t *data, size_t datalen) {
     while (datalen--) {
       DBG::debugWriteByte(*data++);
     }
-    
+
 }
 void DBG::debugWriteHex(uint8_t databyte) {
   uint8_t b1=(databyte>>4)|'0';

--- a/source/dbg.cpp
+++ b/source/dbg.cpp
@@ -11,6 +11,8 @@
 #include "dbg.h"
 #include "sys.h"
 
+
+
 #if defined(DEBUG_ON)
 
 void DBG::updi_st_ptr_l(uint32_t address) {
@@ -190,6 +192,53 @@ void DBG::updi_rep(uint8_t reps) {
     #endif
 }
 
+void DBG::updi_reset() {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("RESET ");
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+void DBG::updi_reset_on() {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("RESET ON");
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+void DBG::updi_reset_off() {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("RESET OFF");
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
+void DBG::updi_post_reset(uint8_t mode) {
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
+    #endif
+    DBG::debugWriteByte(0x0D);
+    DBG::debugWriteByte(0x0A);
+    DBG::debugWriteStr("NewMode ");
+    DBG::debugWriteHex(mode);
+    #ifdef USE_SPIDEBUG
+      PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
+    #endif
+}
+
 void DBG::updi_res(uint32_t data, uint8_t isaddr) {
     #ifdef USE_SPIDEBUG
       PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
@@ -348,9 +397,9 @@ void DBG::debug(char prefix, uint8_t data0){
 
 
 void DBG::debug(const char *str, uint8_t newline) {
-  DBG::debug((const uint8_t *)str, strlen(str), newline);
+  DBG::debug((const uint8_t *)str, strlen(str), newline, 0);
 }
-void DBG::debug(const uint8_t *data, size_t datalen , uint8_t newline) {
+void DBG::debug(const uint8_t *data, size_t datalen , uint8_t newline, uint8_t ashex) {
     #ifdef USE_SPIDEBUG
       PORT(SPIPORT)&=~(1<<SSPIN); //lower SSPIN
     #endif
@@ -358,17 +407,21 @@ void DBG::debug(const uint8_t *data, size_t datalen , uint8_t newline) {
       DBG::debugWriteByte(0x0D);
       DBG::debugWriteByte(0x0A);
     }
-    DBG::debugWriteBytes(data,datalen);
+    DBG::debugWriteBytes(data,datalen,ashex);
     #ifdef USE_SPIDEBUG
       PORT(SPIPORT)|=1<<SSPIN; //raise SSPIN
     #endif
 }
 void DBG::debugWriteStr(const char *str) {
-  DBG::debugWriteBytes((const uint8_t *)str, strlen(str));
+  DBG::debugWriteBytes((const uint8_t *)str, strlen(str),0);
 }
-void DBG::debugWriteBytes(const uint8_t *data, size_t datalen) {
+void DBG::debugWriteBytes(const uint8_t *data, size_t datalen, uint8_t ashex) {
     while (datalen--) {
-      DBG::debugWriteByte(*data++);
+      if(ashex){
+        DBG::debugWriteHex(*data++);
+      } else {
+        DBG::debugWriteByte(*data++);
+      }
     }
 
 }

--- a/source/dbg.h
+++ b/source/dbg.h
@@ -16,6 +16,20 @@
 /* User Configuration goes up here - the rest down below is defaults that you can override
    or stuff that is hardware specific   */
 
+// Uncomment these to enable debug output recording every time one of these UPDI commands is sent and (for load commands) the response.
+// note that this will have NO EFFECT if you have not defined either USE_SPIDEBUG or USE_USARTDEBUG and any required parameters!
+
+//#define DEBUG_STCS
+//#define DEBUG_LDCS
+//#define DEBUG_REP
+//#define DEBUG_STS
+//#define DEBUG_STPTR
+//#define DEBUG_LDS
+//#define DEBUG_KEY
+//#define DEBUG_RESET
+
+
+
 #if defined(__AVR_ATtiny_Zero_One__)
   // tinyAVR 0-series and 1-series parts
   // 3216, 1604, that kind of thing
@@ -295,6 +309,7 @@
 #endif
 
 #if defined(DEBUG_ON)
+
 namespace DBG {
   void initDebug(void);
   void updi_st_ptr_l(uint32_t address);
@@ -312,23 +327,64 @@ namespace DBG {
   void updi_res(uint32_t data, uint8_t isaddr=1);
   void updi_res(uint16_t data, uint8_t isaddr=0);
   void updi_res(uint8_t data);
-  void debug_updi(uint8_t command, uint32_t address, uint16_t data);
-  void debug_updi_ptr(uint8_t command, uint32_t address);
-  void debug_updi(uint8_t command, uint16_t data);
-  void debug_updi(uint8_t command, uint8_t data);
-  void debug_updi_rep(uint8_t data);
-  void debug_updi_rep_w(uint16_t data);
-  void debug_updi(uint8_t command);
+  void updi_reset();
+  void updi_reset_off();
+  void updi_reset_on();
+  void updi_post_reset(uint8_t mode);
   void debug(const char *str, uint8_t newline=1);
-  void debug(const uint8_t *data, size_t length, uint8_t newline=0);
+  void debug(const uint8_t *data, size_t length, uint8_t newline=0, uint8_t ashex=0);
   void debugWriteStr(const char *str);
-  void debugWriteBytes(const uint8_t *data, size_t length);
+  void debugWriteBytes(const uint8_t *data, size_t length, uint8_t ashex=0);
   void debugWriteByte(uint8_t databyte);
   void debugWriteHex(uint8_t databyte);
   void debug(char prefix, uint8_t data0);
   void debug(char prefix, uint8_t data0, uint8_t data1);
   void debug(char prefix, uint8_t data0, uint8_t data1, uint8_t data2);
 }
+#else
+// if debug is not on, we need to deal with the specific DEBUG_(subsystem) defines. Rather than make a mess of everywhere that checks for them by adding another check for DEBUG_ON
+// we'll just undefine them....
+#ifdef DEBUG_STCS
+  #warning "No debug output method is configured, so DEBUG_STCS being undefined"
+  #undef DEBUG_STCS
+#endif
+
+#ifdef DEBUG_LDCS
+  #warning "No debug output method is configured, so DEBUG_LDCS being undefined"
+  #undef DEBUG_LDCS
+#endif
+
+#ifdef DEBUG_STS
+  #warning "No debug output method is configured, so DEBUG_STS being undefined"
+  #undef DEBUG_STS
+#endif
+
+#ifdef DEBUG_LDS
+  #warning "No debug output method is configured, so DEBUG_LDS being undefined"
+  #undef DEBUG_LDS
+#endif
+
+#ifdef DEBUG_STPTR
+  #warning "No debug output method is configured, so DEBUG_STPTR being undefined"
+  #undef DEBUG_STPTR
+#endif
+
+#ifdef DEBUG_KEY
+  #warning "No debug output method is configured, so DEBUG_KEY being undefined"
+  #undef DEBUG_KEY
+#endif
+
+#ifdef DEBUG_REP
+  #warning "No debug output method is configured, so DEBUG_REP being undefined"
+  #undef DEBUG_REP
+#endif
+
+#ifdef DEBUG_RESET
+  #warning "No debug output method is configured, so DEBUG_RESET being undefined"
+  #undef DEBUG_RESET
+#endif
+
+
 #endif
 
 #endif /* DBG_H_ */

--- a/source/dbg.h
+++ b/source/dbg.h
@@ -1,0 +1,334 @@
+/*
+ * dbg.h
+ *
+ * Created:5/11/2020
+ * Author: Spence Konde  (tindie.com/stores/drazzy)
+ * github.com/SpenceKonde
+ */
+
+#ifndef DBG_H_
+#define DBG_H_
+
+#include <avr/io.h>
+#include "sys.h"
+
+
+/* User Configuration goes up here - the rest down below is defaults that you can override
+   or stuff that is hardware specific   */
+
+#if defined(__AVR_ATtiny_Zero_One__)
+  // tinyAVR 0-series and 1-series parts
+  // 3216, 1604, that kind of thing
+
+  #define LED_PORT A
+  #define LED_PIN 7
+
+  // Second LED is used to indicate NVM version, or as an additional debugging aid.
+  #define LED2_PORT A
+  #define LED2_PIN 6
+
+
+  //USARTDEBUG not practical here because only one UART.
+
+
+
+#elif defined( __AVR_ATmega_Mighty__ )
+  // For ATmega16, ATmega32, and the later x4 parts (up to the 1284P).
+  // On the ones with two USARTS, you can use USART debugging.
+  //
+  // Here USART debug output is an option too
+  // at least on parts with the second USART
+  // You should be able to hit 2MBaud with F_CPU=16000000 and DEBUG_BAUDVAL 0 or 1mbaud with 1 if your serial adapter can't handle that.
+  // At 20, though, on classic AVRs, you're out of luck unless you have an adapter that can do 2.5 mbaud...have to go all the way down to 500kbaud (DEBUG_BAUDVAL 4) to divide it to something common.. Good thing almost everyone runs them at 16.
+
+
+
+
+
+#elif defined (__AVR_ATmega_Mini__) || defined(ARDUINO_AVR_LARDU_328E)
+  // For ATmega328 and 168 (P, PB) parts
+  // Same deal as before/ Remember that the buildin LED is on the same pin as SCK on most boards, so you'll want to cadd LEDs on other pinn, defaults to D2
+  // On PB parts can also use second USART. Using the second SPI is not supported.
+
+
+
+#elif defined (__AVR_ATmega_Mega__)
+  // 2560 and that family, like the ones used on the Arduino Mega
+  // Same as the others with extra USARTS, only here you can specify which one if you must
+
+
+#elif defined (__AVR_ATmega_Zero__)
+// 4808, 4809. and the rest of the megaAVR 0-series
+// Same as above, pretty much
+// big difference here is your specify the name of the peripheral instead of the number, and the target baud rate, because we grab the OSCCAL value per datasheet./
+
+#endif
+
+
+/* Defaults and hardware-specific stuff                 */
+/* Shouldn't need to change anything here               */
+/* IF you want to override, copy it to the blocks above */
+
+
+#if defined(__AVR_ATtiny_Zero_One__)
+// tinyAVR 0-series and 1-series parts HOST_RX_PIN 3
+
+  #ifdef USE_SPIDEBUG
+
+      #define SPIDEBUG SPI0
+
+      //SPI0 is on PORTA
+      #define SPIPORT A
+      //PA1, PA3, PA4 are MOSI,SCK,SS on XTINY parts with more than 8 pins, and the ones with 8 pins don't have enough ram to fit the device descriptor so we don't care about them.
+      //On the megasAVR 0-series and AVR DA-series, this would be 0x50 but otherise everything same I think.. not that people are lining up to use those parts as boring programmers!
+      #define MOSIPIN 1
+      #define SCKPIN 3
+
+    #ifndef SSPIN
+    //They get option to change this because they may want to use a different pin,m and they an do that on the parts with the new peripherals that have the SSD bit.
+      #define SSPIN 4
+    #endif
+
+  #endif //emd of SPIDEBUG section for XTINY
+
+  #ifdef USE_USARTDEBUG
+    #error "Only has one USART!"
+  #endif
+
+#elif defined( __AVR_ATmega_Mighty__ )
+// For ATmega16, ATmega32, and the later x4 parts (up to the 1284P).
+
+
+  #ifdef USE_SPIDEBUG
+
+    #define SPIPORT B
+
+    #define MOSIPIN 1
+    #define SCKPIN 3
+    #define SSPIN 4
+  #endif
+
+  #ifdef USE_USARTDEBUG
+    #ifdef UCSR1A
+      #if (!defined(DEBUG_USART)
+        #define DEBUG_USART 1
+      #elif (!(DEBUG_USART==1)
+        #undef DEBUG_USART
+        #define DEBUG_USART 1
+      #endif
+    #else
+      #error "That part doesn't have another USART"
+    #endif
+  #endif
+
+
+#elif defined (__AVR_ATmega_Mini__) || defined(ARDUINO_AVR_LARDU_328E)
+  // For ATmega328 and 168 (P, PB) parts
+
+  #ifdef USE_SPIDEBUG
+
+    #define SPIPORT B
+
+    #define MOSIPIN 3
+    #define SCKPIN 5
+    #define SSPIN 2
+
+  #endif
+
+  #ifdef USE_USARTDEBUG
+    #ifdef UCSR1A
+      #if (!defined(DEBUG_USART)
+        #define DEBUG_USART 1
+      #elif (!(DEBUG_USART==1)
+        #undef DEBUG_USART
+        #define DEBUG_USART 1
+      #endif
+    #else
+      #error "That part doesn't have another USART"
+    #endif
+  #endif
+
+
+
+
+#elif defined (__AVR_ATmega_Mega__)
+// 2560 and that family, like the ones used on the Arduino Mega
+
+  #ifdef USE_SPIDEBUG
+
+    #define SPIPORT D
+
+    #define MOSIPIN 2
+    #define SCKPIN 1
+    #define SSPIN 0
+
+  #endif
+
+  #ifdef USE_USARTDEBUG
+
+    #if (!defined(DEBUG_USART)
+      #define DEBUG_USART 1
+    #endif
+
+    #if (!(DEBUG_USART==1||DEBUG_USART==2||DEBUG_USART==3)
+      #undef DEBUG_USART
+      #define DEBUG_USART 1
+    #endif
+  #endif
+
+#elif defined (__AVR_ATmega_Zero__)
+// 4808, 4809. and the rest of the megaAVR 0-series
+
+  #ifdef USE_SPIDEBUG
+
+    #define SPIDEBUG SPI0
+
+    //SPI0 is on PORTA
+    #define SPIPORT A
+    //PA4, PA6, PA7 are MOSI,SCK,SS on megaAVR 0-series
+    #define MOSIPIN 4
+    #define SCKPIN 6
+
+    #ifndef SSPIN
+      #define SSPIN 7
+    #endif
+
+  #endif //emd of SPIDEBUG
+  #ifdef USE_USARTDEBUG
+    #define DEBUG_TX_PIN 0
+    #define DEBUG_RX_PIN 1
+    #if (!defined(DEBUG_USART)
+      #define DEBUG_USART USART1
+    #endif
+    #if DEBUG_USART==USART1
+      #define DEBUG_TX_PORT C
+    #elif DEBUG_USART==USART2
+      #define DEBUG_TX_PORT F
+    #elif DEBUG_USART==USART3
+      #define DEBUG_TX_PORT B
+    #elif DEBUG_USART==USART0
+      #define DEBUG_TX_PORT A
+    #else
+      #undef DEBUG_USART
+      #define DEBUG_USART USART1
+      #define DEBUG_TX_PORT C
+    #endif
+  #endif //end if USARTDEBUG
+#else
+  #warning "Part not supported - if you didn't provide all the needed pin definitions, that's why it's not compiling"
+#endif //End of the defaults!
+
+
+// Noe we do some general stuff relating the the debugging so they share most of the code...
+#if (defined(USE_SPIDEBUG) && defined(USE_USARTDEBUG))
+  #error "Cannot use both SPI and UART for debugging, pick one"
+#endif
+
+#ifdef USE_SPIDEBUG
+  #define DEBUG_ON
+  #ifdef XAVR
+    #define DEBUGDATA SPIDEBUG.DATA
+    #define DEBUGFLAGS SPIDEBUG.INTFLAGS
+    #define DEBUGSENDNOW SPI_IF_bp
+  #else
+    #ifndef SPDR
+    //means it's one of the ones woth two of them, 0 and 1...
+      #define SPIF SPIF0
+      #define MSTR MSTR0
+      #define WDE WDE0
+      #if (SPIDEBUG==1)
+        #define SPDR SPDR1
+        #define SPSR SPSR1
+        #define SPCR SPCR1
+      #else
+        #define SPDR SPDR0
+        #define SPSR SPSR0
+        #define SPCR SPCR0
+      #endif
+    #endif  //now it has standard names definedm,= so we define them to match the harmonized names...
+    #define DEBUGDATA SPDR
+    #define DEBUGFLAGS SPSR
+    #define DEBUGSENDNOW SPIF
+  #endif
+#endif
+
+#ifdef USE_USARTDEBUG
+  #define DEBUG_ON
+  #ifdef XAVR
+    #if (HOST_USART == DEBUG_USART)
+      #error "Host and Debug cannot be on same USART"
+    #endif
+    #define DEBUGDATA DEBUG_USART.TXDATAL
+    #define DEBUGBAUDREG DEBUG_USART.BAUD
+    #define DEBUGFLAGS DEBUG_USART.STATUS
+    #define DEBUGSENDNOW USART_DREIF_bp
+    #ifndef DEBUG_BAUDRATE
+      #define DEBUG_BAUDRATE 2000000UL
+    #endif
+  #else
+    #define DEBUGSENDNOW UDRE0
+    #if DEBUG_USART==1
+      #define DEBUGDATA UDR1
+      #define DEBUGFLAGS UCSR1A
+      #define DEBUG_UCSRB UCSR1B
+      #define DEBUGBAUDREG UBRR1
+    #elif DEBUG_USART==2
+      #define DEBUGDATA UDR2
+      #define DEBUGFLAGS UCSR2A
+      #define DEBUG_UCSRB UCSR2B
+      #define DEBUGBAUDREG UBRR2
+    #elif DEBUG_USART==3
+      #define DEBUGDATA UDR3
+      #define DEBUGFLAGS UCSR3A
+      #define DEBUG_UCSRB UCSR3B
+      #define DEBUGBAUDREG UBRR3
+    #elif DEBUG_USART==0
+      #error "Using USART other than USART0 to communicate with host not supported on classic AVR"
+    #else
+      #define DEBUG_USART 1
+      #define DEBUGDATA UDR1
+      #define DEBUGFLAGS UCSR1A
+      #define DEBUG_UCSRB UCSR1B
+      #define DEBUGBAUDREG UBRR1
+    #endif
+  #endif
+#endif
+
+#if defined(DEBUG_ON)
+namespace DBG {
+  void initDebug(void);
+  void updi_st_ptr_l(uint32_t address);
+  void updi_st_ptr_w(uint16_t address);
+  void updi_lds(uint32_t address);
+  void updi_lds(uint16_t address);
+  void updi_sts(uint32_t address, uint16_t data);
+  void updi_sts(uint32_t address, uint8_t data);
+  void updi_sts(uint16_t address, uint16_t data);
+  void updi_sts(uint16_t address, uint8_t data);
+  void updi_key();
+  void updi_rep(uint8_t reps);
+  void updi_stcs(uint8_t command, uint8_t data);
+  void updi_ldcs(uint8_t command);
+  void updi_res(uint32_t data, uint8_t isaddr=1);
+  void updi_res(uint16_t data, uint8_t isaddr=0);
+  void updi_res(uint8_t data);
+  void debug_updi(uint8_t command, uint32_t address, uint16_t data);
+  void debug_updi_ptr(uint8_t command, uint32_t address);
+  void debug_updi(uint8_t command, uint16_t data);
+  void debug_updi(uint8_t command, uint8_t data);
+  void debug_updi_rep(uint8_t data);
+  void debug_updi_rep_w(uint16_t data);
+  void debug_updi(uint8_t command);
+  void debug(const char *str, uint8_t newline=1);
+  void debug(const uint8_t *data, size_t length, uint8_t newline=0);
+  void debugWriteStr(const char *str);
+  void debugWriteBytes(const uint8_t *data, size_t length);
+  void debugWriteByte(uint8_t databyte);
+  void debugWriteHex(uint8_t databyte);
+  void debug(char prefix, uint8_t data0);
+  void debug(char prefix, uint8_t data0, uint8_t data1);
+  void debug(char prefix, uint8_t data0, uint8_t data1, uint8_t data2);
+}
+#endif
+
+#endif /* DBG_H_ */

--- a/source/jtag2updi.cpp
+++ b/source/jtag2updi.cpp
@@ -3,95 +3,150 @@
  *
  * Created: 11-11-2017 22:29:58
  * Author : JMR_2
- */ 
+ */
 
 // Includes
 #include "sys.h"
 #include "updi_io.h"
 #include "JICE_io.h"
 #include "JTAG2.h"
+#include "dbg.h"
+#ifdef USE_WDT_RESET
+  #include <avr/wdt.h>
+#endif
 
 /* Internal stuff */
 namespace {
-	// Prototypes
-	void setup();
-	void loop();
+  // Prototypes
+  void setup();
+  void loop();
 }
 
 int main(void)
 {
-	setup();
-	loop();
+  setup();
+  loop();
 }
 
 /* Internal stuff */
 namespace {
-	inline void setup() {
-		/* Initialize MCU */
-		SYS::init();
-	
-		/* Initialize serial links */
-		JICE_io::init();
-		UPDI_io::init();
-		
-		/* Initialize writeable parameters to default values */
-		JTAG2::init();
-		
-	}
+  uint8_t HostTimeoutCount=0;
+  inline void setup() {
+    /* Initialize MCU */
+    //wdt_disable();
+    SYS::init();
+
+    /* Initialize serial links */
+    JICE_io::init();
+    UPDI_io::init();
+
+  }
 
 
-	inline void loop() {
-		while (1) {
-		
-			// Receive command
-			while(!JTAG2::receive());
-			// Process command
-			switch (JTAG2::packet.body[0]) {
-				case JTAG2::CMND_GET_SIGN_ON:
-					JTAG2::sign_on();
-					break;
-				case JTAG2::CMND_GET_PARAMETER:
-					JTAG2::get_parameter();
-					break;
-				case JTAG2::CMND_SET_PARAMETER:
-					JTAG2::set_parameter();
-					break;
-				case JTAG2::CMND_RESET:
-				case JTAG2::CMND_ENTER_PROGMODE:
-					JTAG2::enter_progmode();
-					break;
-				case JTAG2::CMND_SIGN_OFF:
-					// Restore default baud rate before exiting
-					JTAG2::PARAM_BAUD_RATE_VAL = JTAG2::baud_19200;
-					// Change emulator mode to signal that the UPDI unit must be turned off
-					JTAG2::PARAM_EMU_MODE_VAL = JTAG2::emul_mode::EMULATOR_MODE_UNKNOWN;
-				case JTAG2::CMND_LEAVE_PROGMODE:
-					JTAG2::leave_progmode();
-					break;
-				case JTAG2::CMND_GET_SYNC:
-				case JTAG2::CMND_GO:
-					JTAG2::set_status(JTAG2::RSP_OK);
-					break;
-				case JTAG2::CMND_SET_DEVICE_DESCRIPTOR:
-					JTAG2::set_device_descriptor();
-					break;		
-				case JTAG2::CMND_READ_MEMORY:
-					JTAG2::read_mem();
-					break;
-				case JTAG2::CMND_WRITE_MEMORY:
-					JTAG2::write_mem();
-					break;
-				case JTAG2::CMND_XMEGA_ERASE:
-					JTAG2::erase();
-					break;
-				default:
-					JTAG2::set_status(JTAG2::RSP_FAILED);
-					break;
-			}
-			// send response
-			JTAG2::answer();
-			// some commands need to be executed after sending the answer
-			JTAG2::delay_exec();
-		}
-	}
+  inline void loop() {
+    //wdt_enable(WDTO_500MS);
+    while (1) {
+      // Receive command
+      while(!(JTAG2::receive()||(SYS::checkTimeouts() & WAIT_FOR_HOST)));
+      // Process command
+      if (!(SYS::checkTimeouts() & WAIT_FOR_HOST)) {
+        HostTimeoutCount=0;
+        SYS::clearTimeouts(); //clear the timeouts, because WAIT_FOR_TARGET may be set here because of how this is implemented...
+        #ifdef DEBUG_ON
+        DBG::debug('c',JTAG2::packet.body[0]);
+        #endif
+        switch (JTAG2::packet.body[0]) {
+          case JTAG2::CMND_GET_SIGN_ON:
+            JTAG2::sign_on();
+            break;
+          case JTAG2::CMND_GET_PARAMETER:
+            JTAG2::get_parameter();
+            break;
+          case JTAG2::CMND_SET_PARAMETER:
+            JTAG2::set_parameter();
+            break;
+          case JTAG2::CMND_ENTER_PROGMODE:
+            JTAG2::enter_progmode();
+            break;
+          case JTAG2::CMND_SIGN_OFF:
+            // Restore default baud rate before exiting
+            JTAG2::PARAM_BAUD_RATE_VAL = JTAG2::baud_19200;
+            if (JTAG2::ConnectedTo&0x02) {
+              //if this is true, we're talking to the target too! We're better tell it we're done...
+              JTAG2::leave_progmode();
+              JTAG2::go();
+            }
+            JTAG2::ConnectedTo&=0xFE; // no longer talking to host either, anymore.
+            set_status(JTAG2::RSP_OK);
+            break;
+          case JTAG2::CMND_LEAVE_PROGMODE:
+            JTAG2::leave_progmode();
+            break;
+          case JTAG2::CMND_GET_SYNC:
+          case JTAG2::CMND_RESET:
+            JTAG2::set_status(JTAG2::RSP_OK);
+            break;
+          case JTAG2::CMND_GO:
+              JTAG2::go();
+            break;
+          case JTAG2::CMND_SET_DEVICE_DESCRIPTOR:
+            JTAG2::set_device_descriptor();
+            break;
+          case JTAG2::CMND_READ_MEMORY:
+            JTAG2::read_mem();
+            break;
+          case JTAG2::CMND_WRITE_MEMORY:
+            JTAG2::write_mem();
+            break;
+          case JTAG2::CMND_XMEGA_ERASE:
+            JTAG2::erase();
+            break;
+          default:
+            JTAG2::set_status(JTAG2::RSP_FAILED);
+            break;
+        }
+        if (SYS::checkTimeouts() & WAIT_FOR_TARGET) {
+          #ifdef DEBUG_ON
+          DBG::debug('t',SYS::checkTimeouts());
+          #endif
+          // If we got a timeout while waiting for the target during the preceeding command, then warn the host:
+          JTAG2::set_status(JTAG2::RSP_NO_TARGET_POWER); //this error looks like the best fit
+        }
+        // send response
+        JTAG2::answer();
+        // some commands need to be executed after sending the answer
+        JTAG2::delay_exec();
+      } else { // timed out waiting for host communication
+        // We timed out waiting for the host to send something
+        // if we thought we were talking with host, that would be a sign that something went wrong
+        if (JTAG2::ConnectedTo&0x01) {
+          #ifdef DEBUG_ON
+          DBG::debug('t',SYS::checkTimeouts());
+          DBG::debug('h',HostTimeoutCount);
+          #endif
+          if (HostTimeoutCount++>3) {
+            // Time to give up on host, restore default baud rate, and wait for future contact
+            #if defined(DEBUG_ON)
+            DBG::debug("Giving up...");
+            #endif
+            JTAG2::PARAM_BAUD_RATE_VAL = JTAG2::baud_19200;
+            JICE_io::set_baud(JTAG2::baud_19200);
+            JTAG2::ConnectedTo&=0xFE; // no longer talking to host.
+            if (JTAG2::ConnectedTo&0x02) {
+              //if this is true, we're still talking to the target! We're better tell it we're done...
+              JTAG2::leave_progmode();
+              JTAG2::go();
+            }
+          } else { // send a fail and give them a chance to start talking again
+            JTAG2::set_status(JTAG2::RSP_FAILED);
+            // send response
+            JTAG2::answer();
+            // some commands need to be executed after sending the answer
+            JTAG2::delay_exec();
+          }
+        }
+      }
+      SYS::clearTimeouts();
+    }
+  }
 }

--- a/source/parts.h
+++ b/source/parts.h
@@ -1,0 +1,44 @@
+/*
+ *  parts.h
+ *
+ * Created:5/11/2020
+ * Author: Spence Konde  (tindie.com/stores/drazzy)
+ * github.com/SpenceKonde
+ */
+
+#ifndef  PARTS_H_
+#define  PARTS_H_
+
+#include <avr/io.h>
+
+#if  (defined(__AVR_ATtiny3217__) || defined(__AVR_ATtiny1617__) || defined(__AVR_ATtiny1604__) || defined(__AVR_ATtiny1607__) || \
+      defined(__AVR_ATtiny3216__) || defined(__AVR_ATtiny1616__) || defined(__AVR_ATtiny1606__) || defined(__AVR_ATtiny1614__))
+
+      #define __AVR_ATtiny_Zero_One__
+
+
+#elif (defined(__AVR_ATmega16__)    || defined(__AVR_ATmega32__)    || defined(__AVR_ATmega164A__)  || defined(__AVR_ATmega164PA__) || \
+       defined(__AVR_ATmega324A__)  || defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega324PB__) || defined(__AVR_ATmega644A__)  || \
+       defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284__)  || defined(__AVR_ATmega1284P__))
+
+      #define __AVR_ATmega_Mighty__
+
+
+#elif  (defined(__AVR_ATmega641__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__) || \
+        defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__))
+
+      #define __AVR_ATmega_Mega__
+
+
+#elif (defined(__AVR_ATmega328__)   || defined(__AVR_ATmega328P__) ||defined(__AVR_ATmega168A__) || defined(__AVR_ATmega168PA__) || \
+       defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega168PB__) )
+
+      #define __AVR_ATmega_Mini__
+
+#elif (defined(__AVR_ATmega808__) ||defined(__AVR_ATmega1608__) ||defined(__AVR_ATmega3208__) ||defined(__AVR_ATmega4808__) || \
+       defined(__AVR_ATmega808__) ||defined(__AVR_ATmega1608__) ||defined(__AVR_ATmega3208__) ||defined(__AVR_ATmega4808__) )
+
+      #define __AVR_ATmega_Zero__
+
+#endif
+#endif

--- a/source/parts.h
+++ b/source/parts.h
@@ -30,15 +30,21 @@
       #define __AVR_ATmega_Mega__
 
 
-#elif (defined(__AVR_ATmega328__)   || defined(__AVR_ATmega328P__) ||defined(__AVR_ATmega168A__) || defined(__AVR_ATmega168PA__) || \
-       defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega168PB__) )
+#elif (defined(__AVR_ATmega328__)   || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168A__)  || defined(__AVR_ATmega168PA__) || \
+       defined(__AVR_ATmega168__)   || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega168PB__) )
 
       #define __AVR_ATmega_Mini__
 
 #elif (defined(__AVR_ATmega808__) ||defined(__AVR_ATmega1608__) ||defined(__AVR_ATmega3208__) ||defined(__AVR_ATmega4808__) || \
-       defined(__AVR_ATmega808__) ||defined(__AVR_ATmega1608__) ||defined(__AVR_ATmega3208__) ||defined(__AVR_ATmega4808__) )
+       defined(__AVR_ATmega809__) ||defined(__AVR_ATmega1609__) ||defined(__AVR_ATmega3209__) ||defined(__AVR_ATmega4809__) )
 
       #define __AVR_ATmega_Zero__
+
+#elif (defined(__AVR_AVR128DA28__) ||defined(__AVR_AVR128DA32__) ||defined(__AVR_AVR128DA48__) ||defined(__AVR_AVR128DA64__) || \
+       defined(__AVR_AVR64DA28__)  ||defined(__AVR_AVR64DA32__)  ||defined(__AVR_AVR64DA48__)  ||defined(__AVR_AVR64DA64__)  || \
+       defined(__AVR_AVR32DA28__)  ||defined(__AVR_AV324DA32__)  ||defined(__AVR_AVR32DA48__)  )
+
+      #define __AVR_DA__
 
 #endif
 #endif

--- a/source/sys.cpp
+++ b/source/sys.cpp
@@ -25,8 +25,24 @@ void SYS::init(void) {
   #endif
 
   #ifdef XAVR
-    _PROTECTED_WRITE(CLKCTRL.MCLKCTRLB, 0);
-    //PULLUP_ON(UPDI_PORT,UPDI_PIN)
+    #ifdef __AVR_DA__
+      #if (F_CPU == 24000000)
+        /* No division on clock */
+        _PROTECTED_WRITE(CLKCTRL_OSCHFCTRLA, (CLKCTRL_OSCHFCTRLA & ~CLKCTRL_FREQSEL_gm ) | (0x09<< CLKCTRL_FREQSEL_gp ));
+
+      #elif (F_CPU == 20000000)
+        /* No division on clock */
+        _PROTECTED_WRITE(CLKCTRL_OSCHFCTRLA, (CLKCTRL_OSCHFCTRLA & ~CLKCTRL_FREQSEL_gm ) | (0x08<< CLKCTRL_FREQSEL_gp ));
+
+      #elif (F_CPU == 16000000)
+        /* No division on clock */
+        _PROTECTED_WRITE(CLKCTRL_OSCHFCTRLA, (CLKCTRL_OSCHFCTRLA & ~CLKCTRL_FREQSEL_gm ) | (0x07<< CLKCTRL_FREQSEL_gp ));
+      #else
+        #error "F_CPU defined as an unsupported value"
+      #endif
+    #else //0-series or 1-series
+      _PROTECTED_WRITE(CLKCTRL.MCLKCTRLB, 0);
+    #endif
   #else
     #if defined(ARDUINO_AVR_LARDU_328E)
       clock_prescale_set ( (clock_div_t) __builtin_log2(32000000UL / F_CPU));

--- a/source/sys.cpp
+++ b/source/sys.cpp
@@ -3,67 +3,79 @@
  *
  * Created: 02-10-2018 13:07:52
  *  Author: JMR_2
- */ 
+ */
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
 #include <avr/power.h>
-
 #include "sys.h"
+#include "dbg.h"
+#include <stdio.h>
+#include <string.h>
+
+
+#include <stdio.h>
+#include <string.h>
+
+
 
 void SYS::init(void) {
+  #ifdef DEBUG_ON
+    DBG::initDebug();
+  #endif
 
-#ifndef __AVR_ATmega16__
-#	if defined XTINY
-		// Set clock speed to maximum (default 20MHz, or 16MHz set by fuse)
-		_PROTECTED_WRITE(CLKCTRL.MCLKCTRLB, 0);
-		/* Disable unused peripherals */
-		//ToDo
-#	else
-#		if defined(ARDUINO_AVR_LARDU_328E)
-		clock_prescale_set ( (clock_div_t) __builtin_log2(32000000UL / F_CPU));
-#		endif
-		/* Disable digital input buffers on port C */
-		DIDR0 = 0x3F;
-		/* Disable unused peripherals */
-		ACSR = 1 << ACD;		// turn off comparator
-#	endif		
-		/* Enable all UPDI port pull-ups */
-		PORT(UPDI_PORT) = 0xFF;
-		/* Enable all LED port pull-ups, except for the LED pin */
-		PORT(LED_PORT) = 0xFF - (1 << LED_PIN);
-#else
-        /* No interrupts */
-        sei();
-        /* Enable all UPDI port pull-ups */
-        PORT(UPDI_PORT) = 0xFF;
-        /* Enable LED */
-        PORT(LED_PORT) |= (1 << LED_PIN);
-        /* Enable all LED port pull-ups, except for the LED pin */
-        PORT(LED_PORT) = 0xFF - (1 << LED_PIN);
+  #ifdef XAVR
+    _PROTECTED_WRITE(CLKCTRL.MCLKCTRLB, 0);
+    //PULLUP_ON(UPDI_PORT,UPDI_PIN)
+  #else
+    #if defined(ARDUINO_AVR_LARDU_328E)
+      clock_prescale_set ( (clock_div_t) __builtin_log2(32000000UL / F_CPU));
+    #endif
+	  PORT(UPDI_PORT) = 1<<UPDI_PIN;
+  #endif
 
 
-        /* Disable unused peripherals */
-        SPCR &= ~(1<<SPE);
-        ADC  &= ~(1<<ADEN);
-        TWCR &= ~(1<<TWEN);
-
-        /* Disable resources after bootloader */
-        TIFR   = 0x00;
-        TIMSK  = 0x00;
-        TCNT1  = 0x0000;
-        OCR1A  = 0x0000;
-        OCR1B  = 0x0000;
-        TCCR1A = 0x0000;
-        TCCR1B = 0x0000;
-#endif
-
+  DDR(LED_PORT) |= (1 << LED_PIN);
+  #ifdef LED2_PORT
+  DDR(LED2_PORT) |= (1 << LED2_PIN);
+  #endif
+  TIMER_HOST_MAX=HOST_TIMEOUT;
+  TIMER_TARGET_MAX=TARGET_TIMEOUT;
+  #if defined(DEBUG_ON)
+  DBG::debug(0x18,0xC0,0xFF, 0xEE);
+  #endif
 }
 
 void SYS::setLED(void){
-	PORT(LED_PORT) |= 1 << LED_PIN;	
+	PORT(LED_PORT) |= 1 << LED_PIN;
 }
 
 void SYS::clearLED(void){
-	PORT(LED_PORT) &= ~(1 << LED_PIN);	
+	PORT(LED_PORT) &= ~(1 << LED_PIN);
+}
+
+void SYS::setVerLED(void){
+        #ifdef LED2_PORT
+        PORT(LED2_PORT) |= 1 << LED2_PIN;
+        #endif
+}
+
+void SYS::clearVerLED(void){
+        #ifdef LED2_PORT
+        PORT(LED2_PORT) &= ~(1 << LED2_PIN);
+        #endif
+}
+
+/*
+inline void SYS::startTimer()
+inline void SYS::stopTimer()
+
+Timeout mechanisms, 5/2020, Spence Konde
+*/
+
+uint8_t SYS::checkTimeouts() {
+return TIMEOUT_REG;
+}
+void SYS::clearTimeouts() {
+  TIMEOUT_REG=WAIT_FOR_HOST|WAIT_FOR_TARGET;
 }

--- a/source/sys.h
+++ b/source/sys.h
@@ -109,13 +109,13 @@
 	// Can even change the host USART if you want
 
 
-#elif defined (__AVR_ATmega_Zero__ || __AVR_DA__)
+#elif defined (__AVR_ATmega_Zero__ ) || defined( __AVR_DA__)
 // 4808, 4809. and the rest of the megaAVR 0-series
 // Same as above, pretty much
 // big difference here is your specify the name of the peripheral instead of the number, and the target baud rate, because we grab the OSCCAL value per datasheet./
-	#define USE_USARTDEBUG
-	#define DEBUG_USART USART1
-	#define DEBUG_BAUDRATE 2000000UL
+//	#define USE_USARTDEBUG
+//	#define DEBUG_USART USART1
+//	#define DEBUG_BAUDRATE 2000000UL
 
 #endif
 
@@ -243,7 +243,7 @@
 	#	endif
 
 
-#elif defined (__AVR_ATmega_Zero__ || __AVR_DA__)
+#elif defined (__AVR_ATmega_Zero__ ) || defined( __AVR_DA__)
 // 4808, 4809. and the rest of the megaAVR 0-series
 
 

--- a/source/sys.h
+++ b/source/sys.h
@@ -58,7 +58,7 @@
 //	#define USE_SPIDEBUG
 
   //SPIPRESC sets prescaler of SPI clock - it can go *INSANELY* fast, such that very little could keep up with it.
-  
+
   #define SPIPRESC (SPI_CLK2X_bm|SPI_PRESC1_bm)
 
 
@@ -300,9 +300,18 @@
 
 
 // TIMEOUTS
-
+// HOST_TIMEOUT =~250ms
+// TARGET_TIMEOUT=~100ms
+#if (F_CPU==20000000U)
 #define HOST_TIMEOUT 19000
 #define TARGET_TIMEOUT 7800
+#elif (F_CPU==16000000U)
+#define HOST_TIMEOUT 15600
+#define TARGET_TIMEOUT 6250
+#else //8000000U
+#define HOST_TIMEOUT 7800
+#define TARGET_TIMEOUT 3125
+#endif
 
 #ifdef XAVR
 	#define TIMER_ON TCA_SINGLE_CLKSEL_DIV256_gc | TCA_SINGLE_ENABLE_bm

--- a/source/sys.h
+++ b/source/sys.h
@@ -13,11 +13,24 @@
 #include <stdio.h> // for size_t
 #include "parts.h"
 
+//Disable the response signature during burst writes to permit faster writes
 #define NO_ACK_WRITE
 
-
+// Disable the host timeout - this is required for use with avrdude in terminal mode (-t)
+// but with this disabled, can get "stuck" if communication with host is interrupted at 115200 baud
+// as avrdude on next start will try to communicate at 19200 baud. Reset is required to fix this.
+// Potential enhancement - if this is set, while waiting for message from host, ALSO count transitions on the RX pin
+// If we see a bunch of transitions, but no received characters, we know the host is using the wrong baud rate, and
+// so, switch back to 19200 baud.
 //#define DISABLE_HOST_TIMEOUT
+
+// Disable the timeout waiting for response from target. Probablty not necessary to set. With this disabled, if the target is expected to respond
+// but does not, jtag2updi will get stuck waiting for it.
+
 //#define DISABLE_TARGET_TIMEOUT
+
+// this will include the SIB, deduced NVM version, and silicon revision in early responses to SET_DEVICE_DESCRIPTPOR (for SIB and NVM version) and ENTER_PROGMODE (for silicon rev)
+#define INCLUDE_EXTRA_INFO_JTAG
 
 
 // Auxiliary Macros
@@ -83,8 +96,8 @@
 	// On PB parts can also use second USART. Using the second SPI is not supported.
 
 
-//	#define USE_SPIDEBUG
-//	#define SPIPRESC (0x05)
+	//#define USE_SPIDEBUG
+	//#define SPIPRESC (0x05)
 
 
 

--- a/source/sys.h
+++ b/source/sys.h
@@ -16,14 +16,15 @@
 #define NO_ACK_WRITE
 
 
-//#define USE_WDT_RESET
+//#define DISABLE_HOST_TIMEOUT
+//#define DISABLE_TARGET_TIMEOUT
 
 
 // Auxiliary Macros
 #define CONCAT(A,B) A##B
 //#define CONCAT3(A,B,C) A##B##C
-#if __AVR_ARCH__ == 103
-//We'll call these ones XAVR for purposes of defines, instead of XTINY, so someone could do this with a x08-series part
+#if (__AVR_ARCH__ == 103) || (__AVR_ARCH__ == 104)
+//We'll call these ones XAVR for purposes of defines, instead of XTINY. This encompases megaAVR 0-series and DA-series parts
 
 	#define XAVR
 	#	define PIN(x) CONCAT(VPORT,x).IN
@@ -95,7 +96,7 @@
 	// Can even change the host USART if you want
 
 
-#elif defined (__AVR_ATmega_Zero__)
+#elif defined (__AVR_ATmega_Zero__ || __AVR_DA__)
 // 4808, 4809. and the rest of the megaAVR 0-series
 // Same as above, pretty much
 // big difference here is your specify the name of the peripheral instead of the number, and the target baud rate, because we grab the OSCCAL value per datasheet./
@@ -229,7 +230,7 @@
 	#	endif
 
 
-#elif defined (__AVR_ATmega_Zero__)
+#elif defined (__AVR_ATmega_Zero__ || __AVR_DA__)
 // 4808, 4809. and the rest of the megaAVR 0-series
 
 
@@ -299,19 +300,7 @@
 
 
 
-// TIMEOUTS
-// HOST_TIMEOUT =~250ms
-// TARGET_TIMEOUT=~100ms
-#if (F_CPU==20000000U)
-#define HOST_TIMEOUT 19000
-#define TARGET_TIMEOUT 7800
-#elif (F_CPU==16000000U)
-#define HOST_TIMEOUT 15600
-#define TARGET_TIMEOUT 6250
-#else //8000000U
-#define HOST_TIMEOUT 7800
-#define TARGET_TIMEOUT 3125
-#endif
+
 
 #ifdef XAVR
 	#define TIMER_ON TCA_SINGLE_CLKSEL_DIV256_gc | TCA_SINGLE_ENABLE_bm
@@ -343,6 +332,23 @@
 #ifndef F_CPU
 	# warning "F_CPU not defined, assuming 16MHz"
 	#	define F_CPU 16000000U
+#endif
+
+// TIMEOUTS
+// HOST_TIMEOUT =~250ms
+// TARGET_TIMEOUT=~100ms
+#if (F_CPU==20000000U)
+	#define HOST_TIMEOUT 19000
+	#define TARGET_TIMEOUT 7800
+#elif (F_CPU==24000000U)
+	#define HOST_TIMEOUT 23400
+	#define TARGET_TIMEOUT 9375
+#elif (F_CPU==16000000U)
+	#define HOST_TIMEOUT 15600
+	#define TARGET_TIMEOUT 6250
+#else //8000000U
+	#define HOST_TIMEOUT 7800
+	#define TARGET_TIMEOUT 3125
 #endif
 
 #ifndef UPDI_BAUD

--- a/source/sys.h
+++ b/source/sys.h
@@ -3,173 +3,415 @@
  *
  * Created: 02-10-2018 13:07:18
  *  Author: JMR_2
- */ 
+ */
 
 #ifndef SYS_H_
 #define SYS_H_
 
-#include<avr/io.h>
+#include <avr/io.h>
+#include <string.h>
+#include <stdio.h> // for size_t
+#include "parts.h"
 
-// See if we are compiling for an UPDI chip (xmega3 core)
-#if __AVR_ARCH__ == 103
-# define XTINY
-#endif
+#define NO_ACK_WRITE
+
+
+//#define USE_WDT_RESET
+
 
 // Auxiliary Macros
 #define CONCAT(A,B) A##B
-#if defined XTINY
-#   define PIN(x) CONCAT(VPORT,x).IN
-#   define PORT(x) CONCAT(VPORT,x).OUT
-#   define DDR(x) CONCAT(VPORT,x).DIR
+//#define CONCAT3(A,B,C) A##B##C
+#if __AVR_ARCH__ == 103
+//We'll call these ones XAVR for purposes of defines, instead of XTINY, so someone could do this with a x08-series part
+
+	#define XAVR
+	#	define PIN(x) CONCAT(VPORT,x).IN
+	#	define PORT(x) CONCAT(VPORT,x).OUT
+	#	define DDR(x) CONCAT(VPORT,x).DIR
+//	# define PULLUP_ON(x,y) CONCAT(PORT,x).CONCAT3(PIN,y,CTRL)=0x04
+//	# define PULLUP_OFF(x,y) CONCAT(PORT,x).CONCAT3(PIN,y,CTRL)=0x04
+
 #else
-#   define PIN(x) CONCAT(PIN,x)
-#   define PORT(x) CONCAT(PORT,x)
-#   define DDR(x) CONCAT(DDR,x)
+
+	#	define PIN(x) CONCAT(PIN,x)
+	#	define PORT(x) CONCAT(PORT,x)
+	#	define DDR(x) CONCAT(DDR,x)
+
 #endif
 
-// Configuration for Arduino Mega
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-#   ifndef UPDI_PORT
-#       define UPDI_PORT D
-#   endif
+/* User Configuration goes up here - the rest down below is defaults that you can override
+   or stuff that is hardware specific   */
 
-#   ifndef UPDI_PIN
-#       define UPDI_PIN 3
-#   endif
+#if defined(__AVR_ATtiny_Zero_One__)
+	// tinyAVR 0-series and 1-series parts
+	// 3216, 1604, that kind of thing
 
-#   ifndef LED_PORT
-#       define LED_PORT B
-#   endif
+	#define LED_PORT A
+	#define LED_PIN 7
 
-#   ifndef LED_PIN
-#       define LED_PIN 7
-#   endif
+	// Second LED is used to indicate NVM version, or as an additional debugging aid.
+	#define LED2_PORT A
+	#define LED2_PIN 6
 
-#   ifndef UPDI_IO_TYPE
-#       define UPDI_IO_TYPE 2
-#   endif
+  //USARTDEBUG not practical here because only one UART.
+//	#define USE_SPIDEBUG
 
-// Configuration for AVR-0/1
-#elif defined XTINY
-#   ifndef UPDI_PORT
-#       define UPDI_PORT B
-#   endif
+  //SPIPRESC sets prescaler of SPI clock - it can go *INSANELY* fast, such that very little could keep up with it.
+  
+  #define SPIPRESC (SPI_CLK2X_bm|SPI_PRESC1_bm)
 
-#   ifndef UPDI_PIN
-#       define UPDI_PIN 0
-#   endif
 
-#   ifndef LED_PORT
-#       define LED_PORT B
-#   endif
+#elif defined( __AVR_ATmega_Mighty__ )
+	// For ATmega16, ATmega32, and the later x4 parts (up to the 1284P).
+	// On the ones with two USARTS, you can use USART debugging.
+	//
+	// Here USART debug output is an option too
+	// at least on parts with the second USART
+	// You should be able to hit 2MBaud with F_CPU=16000000 and DEBUG_BAUDVAL 0 or 1mbaud with 1 if your serial adapter can't handle that.
+	// At 20, though, on classic AVRs, you're out of luck unless you have an adapter that can do 2.5 mbaud...have to go all the way down to 500kbaud (DEBUG_BAUDVAL 4) to divide it to something common.. Good thing almost everyone runs them at 16.
+	// #define USE_USARTDEBUG
+	// #define DEBUG_BAUDVAL 0
 
-#   ifndef LED_PIN
-#       define LED_PIN 1
-#   endif
 
-#   ifndef UPDI_IO_TYPE
-#       define UPDI_IO_TYPE 2
-#   endif
-//  These are currently used only for AVR-0/1 chips
-//  Select which USART peripheral is being used for host PC communication
-//  Also, indicate the port/pin of the HOST_USART Tx pin
-#   ifndef HOST_USART
-#       define HOST_USART USART0
-#   endif
 
-#   ifndef HOST_TX_PORT
-#       define HOST_TX_PORT B
-#   endif
 
-#   ifndef HOST_TX_PIN
-#       define HOST_TX_PIN 2
-#   endif
+#elif defined (__AVR_ATmega_Mini__) || defined(ARDUINO_AVR_LARDU_328E)
+	// For ATmega328 and 168 (P, PB) parts
+	// Same deal as before/ Remember that the buildin LED is on the same pin as SCK on most boards, so you'll want to cadd LEDs on other pinn, defaults to D2
+	// On PB parts can also use second USART. Using the second SPI is not supported.
 
-// Default configuration (suitable for ATmega 328P and similar devices @16MHz)
-#else
-#   ifndef UPDI_PORT
-#       define UPDI_PORT D
-#   endif
 
-#   ifndef UPDI_PIN
-#       define UPDI_PIN 6
-#   endif
+//	#define USE_SPIDEBUG
+//	#define SPIPRESC (0x05)
 
-#   ifndef LED_PORT
-#       define LED_PORT B
-#   endif
 
-#   ifndef LED_PIN
-#       define LED_PIN 5
-#   endif
+
+#elif defined (__AVR_ATmega_Mega__)
+	// 2560 and that family, like the ones used on the Arduino Mega
+	// Same as the others with extra USARTS, only here you can specify which one if you must
+	// #define USE_USARTDEBUG
+	// #define DEBUG_USART 2
+	// Can even change the host USART if you want
+
+
+#elif defined (__AVR_ATmega_Zero__)
+// 4808, 4809. and the rest of the megaAVR 0-series
+// Same as above, pretty much
+// big difference here is your specify the name of the peripheral instead of the number, and the target baud rate, because we grab the OSCCAL value per datasheet./
+	#define USE_USARTDEBUG
+	#define DEBUG_USART USART1
+	#define DEBUG_BAUDRATE 2000000UL
+
 #endif
+
+
+/* Defaults and hardware-specific stuff 								*/
+/* Shouldn't need to change anything here 							*/
+/* IF you want to override, copy it to the blocks above */
+
+
+#if defined(__AVR_ATtiny_Zero_One__)
+// tinyAVR 0-series and 1-series parts
+
+	#	ifndef UPDI_PORT
+	#		define UPDI_PORT B
+	#	endif
+
+	#	ifndef UPDI_PIN
+	#		define UPDI_PIN 0
+	#	endif
+
+	#	ifndef LED_PORT
+	#		define LED_PORT B
+	#	endif
+
+	#	ifndef LED_PIN
+	#		define LED_PIN 1
+	#	endif
+
+	#	ifndef HOST_USART
+	#		define HOST_USART USART0
+	#	endif
+
+	#	ifndef HOST_TX_PORT
+	#		define HOST_TX_PORT B
+	#	endif
+
+	#	ifndef HOST_TX_PIN
+	#		define HOST_TX_PIN 2
+	#	endif
+
+	#	ifndef HOST_RX_PIN
+	#		define HOST_RX_PIN 3
+	#	endif
+
+#elif defined( __AVR_ATmega_Mighty__ )
+// For ATmega16, ATmega32, and the later x4 parts (up to the 1284P).
+
+
+	#	ifndef HOST_USART
+	#		define HOST_USART 0
+	#	endif
+
+	#	ifndef HOST_USART
+	#		define HOST_USART 0
+	#	endif
+
+	#	ifndef UPDI_PORT
+	#		define UPDI_PORT C
+	#	endif
+
+	#	ifndef UPDI_PIN
+	#		define UPDI_PIN 7
+	#	endif
+
+	#	ifndef LED_PORT
+	#		define LED_PORT B
+	#	endif
+
+	#	ifndef LED_PIN
+	#		define LED_PIN 7
+	#	endif
+
+
+#elif defined (__AVR_ATmega_Mini__) || defined(ARDUINO_AVR_LARDU_328E)
+	// For ATmega328 and 168 (P, PB) parts
+
+
+	#	ifndef UPDI_PORT
+	#		define UPDI_PORT D
+	#	endif
+
+	#	ifndef UPDI_PIN
+	#		define UPDI_PIN 6
+	#	endif
+
+	#ifdef USE_SPIDEBUG
+
+		#	ifndef LED_PORT
+		#		define LED_PORT C
+		#	endif
+
+		#	ifndef LED_PIN
+		#		define LED_PIN 5
+		#	endif
+
+	#else
+
+		#	ifndef LED_PORT
+		#		define LED_PORT B
+		#	endif
+
+		#	ifndef LED_PIN
+		#		define LED_PIN 5
+		#	endif
+
+	#endif
+
+#elif defined (__AVR_ATmega_Mega__)
+// 2560 and that family, like the ones used on the Arduino Mega
+
+	#	ifndef UPDI_PORT
+	#		define UPDI_PORT D
+	#	endif
+
+	#	ifndef UPDI_PIN
+	#		define UPDI_PIN 3
+	#	endif
+
+	#	ifndef LED_PORT
+	#		define LED_PORT B
+	#	endif
+
+	#	ifndef LED_PIN
+	#		define LED_PIN 7
+	#	endif
+
+
+#elif defined (__AVR_ATmega_Zero__)
+// 4808, 4809. and the rest of the megaAVR 0-series
+
+
+	#	ifndef UPDI_PORT
+	#		define UPDI_PORT B
+	#	endif
+
+	#	ifndef UPDI_PIN
+	#		define UPDI_PIN 0
+	#	endif
+
+	#	ifndef LED_PORT
+	#		define LED_PORT B
+	#	endif
+
+	#	ifndef LED_PIN
+	#		define LED_PIN 1
+	#	endif
+
+	#	ifndef HOST_USART
+	#		define HOST_USART USART0
+	#	endif
+
+	#	ifndef HOST_TX_PORT
+	#		define HOST_TX_PORT A
+	#	endif
+
+	#	ifndef HOST_TX_PIN
+	#		define HOST_TX_PIN 0
+	#	endif
+
+	#	ifndef HOST_RX_PIN
+	#		define HOST_RX_PIN 1
+	#	endif
+
+#else
+	#warning "Part not supported - if you didn't provide all the needed pin definitions, that's why it's not compiling"
+#endif //End of the defaults!
+
+// The ATmega16 has no 0 after the UART register names
+#ifndef XAVR
+	#ifndef UDRE0
+		#define UDRE0 UDRE
+	#endif
+	#ifndef U2X0
+		#define U2X0 U2X
+	#endif
+	#ifndef TXEN0
+		#define TXEN0 TXEN
+	#endif
+	#ifndef UBRR0
+		#define UBRR0 UBRRL
+	#endif
+	#ifndef USCR0A
+		#define USCR0A USCRA
+	#endif
+	#ifndef USCR0B
+		#define USCR0B USCRB
+	#endif
+	#ifndef RXC0
+		#define RXC0 RXC
+	#endif
+	#ifndef UDR0
+		#define UDR0 UDR
+	#endif
+#endif
+
+
+
+// TIMEOUTS
+
+#define HOST_TIMEOUT 19000
+#define TARGET_TIMEOUT 7800
+
+#ifdef XAVR
+	#define TIMER_ON TCA_SINGLE_CLKSEL_DIV256_gc | TCA_SINGLE_ENABLE_bm
+	#define TIMER_OFF TCA_SINGLE_CLKSEL_DIV256_gc
+	#define TIMEOUT_REG TCA0.SINGLE.INTFLAGS
+	#define TIMER_CONTROL_REG TCA0.SINGLE.CTRLA
+	#define TIMER_COUNT_REG TCA0.SINGLE.CNT
+	#define TIMER_HOST_MAX TCA0.SINGLE.CMP0
+	#define TIMER_TARGET_MAX TCA0.SINGLE.CMP1
+	#define WAIT_FOR_HOST TCA_SINGLE_CMP0_bm
+	#define WAIT_FOR_TARGET TCA_SINGLE_CMP1_bm
+	#define TIMER_RESET_REG TCA0.SINGLE.CTRLESET
+	#define TIMER_RESET_CMD TCA_SINGLE_CMD_RESTART_gc
+#else
+	#define TIMER_ON 0x04
+	#define TIMER_OFF 0x00
+	#define TIMEOUT_REG TIFR1
+	#define TIMER_CONTROL_REG TCCR1B
+	#define TIMER_COUNT_REG TCNT1
+	#define TIMER_HOST_MAX OCR1A
+	#define TIMER_TARGET_MAX OCR1B
+	#define WAIT_FOR_HOST (1<<OCF1A)
+	#define WAIT_FOR_TARGET (1<<OCF1B)
+#endif
+
+
 
 
 #ifndef F_CPU
-#   define F_CPU 16000000U
+	# warning "F_CPU not defined, assuming 16MHz"
+	#	define F_CPU 16000000U
 #endif
 
 #ifndef UPDI_BAUD
-#   define UPDI_BAUD 225000U    // (max 225000 min approx. F_CPU/100)
+	#	define UPDI_BAUD 225000U	// (max 225000 min approx. F_CPU/100)
 #endif
 
 /*
  * Available UPDI I/O types are:
  *
- * 1 - timer sofware UART:      Compatible only with Mega328P and other AVRs with identical 8 bit timer 0.
- *                              Only the OC0A pin can be used for UPDI I/O. Slightly faster upload speed for a given UPDI_BAUD value.
+ * 1 - timer sofware UART:		Compatible only with Mega328P and other AVRs with identical 8 bit timer 0.
+ *								Only the OC0A pin can be used for UPDI I/O. Slightly faster upload speed for a given UPDI_BAUD value.
  *
- * 2 - bitbang software UART:   Compatible with many chips and broad choice of UPDI pins are selectable.
- *                              Slightly slower upload speed for a given UPDI_BAUD value. Download speed is the same.
+ * 2 - bitbang software UART:	Compatible with many chips and broad choice of UPDI pins are selectable.
+ *								Slightly slower upload speed for a given UPDI_BAUD value. Download speed is the same.
  */
 #ifndef UPDI_IO_TYPE
-#   define UPDI_IO_TYPE 2
+	#	define UPDI_IO_TYPE 2
 #endif
 
 // Flash constants class
-#if defined XTINY
-    template <typename T>
-    using FLASH = const T;
+#if defined XAVR
+	template <typename T>
+	using FLASH = const T;
 #else
-#   include <avr/pgmspace.h>
-#   define FLASH const PROGMEM flash
+#	include <avr/pgmspace.h>
+#	define FLASH const PROGMEM flash
 
-    template <typename T>
-    class flash {
-        private:
-        const T data;
+	template <typename T>
+	class flash {
+		private:
+		const T data;
 
-        public:
-        // normal constructor
-        constexpr flash (T _data) : data(_data) {}
-        // default constructor
-        constexpr flash () : data(0) {}
+		public:
+		// normal constructor
+		constexpr flash (T _data) : data(_data) {}
+		// default constructor
+		constexpr flash () : data(0) {}
 
-        operator T() const {
-            switch (sizeof(T)) {
-                case 1: return pgm_read_byte(&data);
-                case 2: return pgm_read_word(&data);
-                case 4: return pgm_read_dword(&data);
-            }
-        }
-    };
+		operator T() const {
+			switch (sizeof(T)) {
+				case 1: return pgm_read_byte(&data);
+				case 2: return pgm_read_word(&data);
+				case 4: return pgm_read_dword(&data);
+			}
+		}
+	};
 #endif
 
-#if defined XTINY
-    // Note: adapted from MicroChip appnote TB3216 "Getting Started with USART"
-    constexpr unsigned int baud_reg_val(unsigned long baud) {
-        return  (F_CPU * 64.0) / (16.0 * baud) + 0.5;
-    }
+#if defined XAVR
+	// Note: adapted from MicroChip appnote TB3216 "Getting Started with USART"
+	constexpr unsigned int baud_reg_val(unsigned long baud) {
+		return  (F_CPU * 64.0) / (16.0 * baud) + 0.5;
+	}
 #else
-    constexpr unsigned int baud_reg_val(unsigned long baud) {
-        return F_CPU/(baud * 8.0) - 0.5;
-    }
+	constexpr unsigned int baud_reg_val(unsigned long baud) {
+		return F_CPU/(baud * 8.0) - 0.5;
+	}
 #endif
 
 namespace SYS {
-    void init(void);
-    void setLED(void);
-    void clearLED(void);
+	uint8_t checkTimeouts(void);
+	void clearTimeouts(void);
+	inline void startTimer(void) __attribute__((always_inline));
+	inline void startTimer(void) {
+  #ifdef TIMER_RESET_REG //some timers have a reset register.
+  TIMER_RESET_REG=TIMER_RESET_CMD;
+  #else
+  TIMER_COUNT_REG=0;
+  #endif
+  TIMER_CONTROL_REG=TIMER_ON;
+	}
+	inline void stopTimer(void) __attribute__((always_inline));
+	inline void stopTimer(void){ TIMER_CONTROL_REG=TIMER_OFF; }
+	void init(void);
+	void setLED(void);
+	void clearLED(void);
+	void setVerLED(void);
+	void clearVerLED(void);
 }
 
 #endif /* SYS_H_ */

--- a/source/updi_io.cpp
+++ b/source/updi_io.cpp
@@ -3,7 +3,7 @@
  *
  * Created: 18-11-2017 10:36:54
  *  Author: JMR_2
- */ 
+ */
 
 
 
@@ -80,7 +80,7 @@ uint8_t UPDI_io::put(ctrl c)
 		wait_for_bit();
 		DDR(UPDI_PORT) &= ~(1 << UPDI_PIN);
 	};
-	
+
 	stop_timer();
 	/* Send falling edge */
 	OCR0A = BIT_TIME - 1;
@@ -96,10 +96,10 @@ uint8_t UPDI_io::put(ctrl c)
 			break_pulse();
 			setup_bit_low();
 			wait_for_bit();
-			DDR(UPDI_PORT) |= (1 << UPDI_PIN);	
+			DDR(UPDI_PORT) |= (1 << UPDI_PIN);
 		case single_break:
 			break_pulse();
-			wait_for_bit();	
+			wait_for_bit();
 			break;
 		case enable:
 		/*
@@ -128,7 +128,7 @@ uint8_t UPDI_io::get() {
 	TCNT0 = 12;		// overhead time; needs to be calibrated
 	/* Make sure overflow flag is reset */
 	TIFR0 = (1 << OCF0A);
-	
+
 	/* Must disable pull-up, because the UPDI UART just sends very short output pulses at the beginning of each bit time. */
 	/* If pull up is enabled, there will be a drift to high state that results in erroneous input sampling. */
 	/* As a side effect, random electrical fluctuations of the input prevent an infinite wait loop */
@@ -221,4 +221,4 @@ namespace {
 }
 
 
-#endif //__AVR_ATmega16__
+#endif

--- a/source/updi_io_soft.cpp
+++ b/source/updi_io_soft.cpp
@@ -3,7 +3,7 @@
  *
  * Created: 11-08-2018 22:08:14
  *  Author: Cristian Balint <cristian dot balint at gmail dot com>
- */
+ */ 
 
 
 // Includes (note: sys.h defines F_CPU, so it should be included before util/delay.h)

--- a/source/updi_io_soft.cpp
+++ b/source/updi_io_soft.cpp
@@ -3,12 +3,13 @@
  *
  * Created: 11-08-2018 22:08:14
  *  Author: Cristian Balint <cristian dot balint at gmail dot com>
- */ 
+ */
 
 
 // Includes (note: sys.h defines F_CPU, so it should be included before util/delay.h)
 #include "sys.h"
 #include "updi_io.h"
+#include "dbg.h"
 
 #include <avr/io.h>
 #include <util/delay.h>
@@ -53,48 +54,61 @@ uint8_t UPDI_io::get() {
         DDR(UPDI_PORT)  &= ~(1 << UPDI_PIN);
         // no pullup
         PORT(UPDI_PORT) &= ~(1 << UPDI_PIN);
-
+        SYS::startTimer();
         uint8_t c;
-
         __asm volatile
         (
-            ASM_MACROS
-            " ldi  %0, 128 \n\t"                            // variable will receive return data, doubles as counter
+            " ldi  %0, 128 \n\t"        // init
 
             // wait for start edge
             "WaitStart: \n\t"
+            " ld r18,%a[timerflags] \n\t" // load the timer flags to r18. which isn't needed until later
+            " andi r18,%[targflag]  \n\t"      // AND with WAIT_FOR_TARGET
+            " brne EndByte \n\t"       // If the product of the ANDI operation was 0, the BRNE will jump it out of here
             " sbic %[uart_port], %[uart_pin] \n\t"
             " rjmp WaitStart \n\t"
+            // all that stuff with the timer will add 4 cycles on a classic AVR and 3 on a XAVR.
+            // so thhe "scatter" introduced by this will be in the range 0~6 or 0~5 ias opposed to
+            // 0~2 like it was before.
 
-            // skew into middle of first data bit
-            " delay_cc %[rxdelay] + %[rxdelay] /2 \n\t"     // 1.5 bit cycle delay and leave carry = 0 for next loop
+            // skew into middle of bit
+            " ldi r18, %[rxdelay] /2 + 6/3  \n\t"  // 0.5 bit cycle delay -
+            "HBitDelay: \n\t"
+            " dec r18 \n\t"
+            " brne HBitDelay \n\t"
 
             // 8 bits
             "RxBLoop: \n\t"
-            " sbic %[uart_port], %[uart_pin] \n\t"          // carry = 0 here; check I/O data
-            " sec \n\t"                                     // if data = 1, set carry
-            " nop \n\t"                                     // correct loop execution time to 6 cycles
-            " delay (%[rxdelay] - 6/3) \n\t"                // 1 bit time delay, minus loop execution time
-            " ror %0 \n\t"                                  // store I/O bit; will set carry when loop ends
+            " ldi r18, %[rxdelay] - 6/3 \n\t"  // 1 bit cycle delay
+            "RxBDelay: \n\t"
+            " subi r18, 1 \n\t"
+            " brne RxBDelay \n\t"
+      " sbic %[uart_port], %[uart_pin] \n\t"
+      " sec \n\t"
+      " ror %0 \n\t"
             " brcc RxBLoop \n\t"
 
-            // Wait 1 bit time: skip to centre of 1st stop bit (ignore parity).
-            // The function returns approx 1.5 bit times before the 2nd stop bit completes
-            // to allow burst reads at high UPDI speeds on 8MHz chips.
-            // This time needs to be compensated in the Tx function.
-            " delay %[rxdelay] \n\t"
-
+            // Wait approx. 2 bit times: skip to centre of 1st stop bit (ignore parity).
+        // The function returns approx 1.5 bit times before the 2nd stop bit completes
+      // to allow burst reads at high UPDI speeds on 8MHz chips.
+      // This time needs to be compensated in the Tx function.
+            " ldi r18, 2 * %[rxdelay] \n\t"  // delay counter
+            "StopDelay: \n\t"
+            " dec r18 \n\t"
+            " brne StopDelay \n\t"
+            "EndByte: \n\t"
 
             : "=r" (c)
             : [uart_port] "i" (_SFR_IO_ADDR(PIN(UPDI_PORT))),
               [uart_pin]  "i" (UPDI_PIN),
-              [rxdelay]   "i" (BITTIME)
+              [rxdelay]   "i" (BITTIME),
+              [targflag]  "M" (WAIT_FOR_TARGET),
+              [timerflags]"e" (_SFR_MEM_ADDR(TIMEOUT_REG))
             : "r18"
         );
-
         // re-enable pull up
         PORT(UPDI_PORT) |= (1 << UPDI_PIN);
-
+        SYS::stopTimer();
         return c;
 }
 


### PR DESCRIPTION
* Adds support for DA-series parts, reads SIB to determine whether to use v1 or v2 commands
* jtag2updi should now work on atmega x4, atmega x0, atmega x1, and megaAVR 0-series parts
* Adds debug channel (dbg.h, dbg.cpp), disabled by default; can use SPI or USART (on devices with more than one USART). USART debug not tested.
* Add support (not used) for a second LED
* Adds timeouts on getting characters from UPDI or from host using TCA0 or TIMER1
* Removes the TEMP register stuff
* Nothing documented in README.md >.<

Sorry for this all being in one giant commit, rather than smaller ones with informative commit messages >.<