### PR TITLE
Highlight new python3 usage for AVR JTAG ICE v2.0 stick.

### DIFF
--- a/tools/avrjtagicev2/README.md
+++ b/tools/avrjtagicev2/README.md
@@ -61,7 +61,7 @@ To burn the USB module, use [avr-aosp.py](https://github.com/cbalint13/avr-aosp/
 1) Erase content of module:
 
 ```
-python2 avr-aosp.py -op erase
+python3 avr-aosp.py -op erase
 
 INFO
 
@@ -85,7 +85,7 @@ ERASE program memory
 2) Upload the firmware:
 
 ```
-python2 avr-aosp.py -op write -file ../../build/JTAG2UPDI.hex
+python3 avr-aosp.py -op write -file ../../build/JTAG2UPDI.hex
 
 INFO
 


### PR DESCRIPTION
Hi @ElTangas ,

Minor update in the documentation to highlight the upgrade to python3 [1] for the AOSP tool procedure.

[1] https://github.com/cbalint13/avr-aosp/commit/77fe95f02bb9f3ea5c5a358c978d1f25b0cca5cf

Thank you !
