### PR TITLE
Revert "Add more supported baudrates"

### DIFF
--- a/source/JICE_io.cpp
+++ b/source/JICE_io.cpp
@@ -14,39 +14,7 @@
 namespace {
   // *** Baud rate lookup table for UBRR0 register ***
   // Indexed by valid values for PARAM_BAUD_RATE_VAL (defined in JTAG2.h)
-  FLASH<uint16_t> baud_tbl[28] = {
-    baud_reg_val(2400),
-    baud_reg_val(4800),
-    baud_reg_val(9600),
-    baud_reg_val(19200),
-    baud_reg_val(38400),
-    baud_reg_val(57600),
-    baud_reg_val(115200),
-    baud_reg_val(14400),
-    // Extension to jtagmkII protocol: extra baud rates, standard series.
-    baud_reg_val(153600);
-    baud_reg_val(230400);
-    baud_reg_val(460800);
-    baud_reg_val(921600);
-    // Extension to jtagmkII protocol: extra baud rates, binary series.
-    baud_reg_val(128000);
-    baud_reg_val(256000);
-    baud_reg_val(512000);
-    baud_reg_val(1024000);
-    // Extension to jtagmkII protocol: extra baud rates, decimal series.
-    baud_reg_val(150000);
-    baud_reg_val(200000);
-    baud_reg_val(250000);
-    baud_reg_val(300000);
-    baud_reg_val(400000);
-    baud_reg_val(500000);
-    baud_reg_val(600000);
-    baud_reg_val(666666);
-    baud_reg_val(1000000);
-    baud_reg_val(1500000);
-    baud_reg_val(2000000);
-    baud_reg_val(3000000);
-    };
+  FLASH<uint16_t> baud_tbl[8] = {baud_reg_val(2400), baud_reg_val(4800), baud_reg_val(9600), baud_reg_val(19200), baud_reg_val(38400), baud_reg_val(57600), baud_reg_val(115200), baud_reg_val(14400)};
 }
 
 // Functions

--- a/source/JTAG2.h
+++ b/source/JTAG2.h
@@ -32,32 +32,8 @@ namespace JTAG2 {
     BAUD_57600,
     BAUD_115200,
     BAUD_14400,
-    // Extension to jtagmkII protocol: extra baud rates, standard series.
-    BAUD_153600,
-    BAUD_230400,
-    BAUD_460800,
-    BAUD_921600,
-    // Extension to jtagmkII protocol: extra baud rates, binary series.
-    BAUD_128000,
-    BAUD_256000,
-    BAUD_512000,
-    BAUD_1024000,
-    // Extension to jtagmkII protocol: extra baud rates, decimal series.
-    BAUD_150000,
-    BAUD_200000,
-    BAUD_250000,
-    BAUD_300000,
-    BAUD_400000,
-    BAUD_500000,
-    BAUD_600000,
-    BAUD_666666,
-    BAUD_1000000,
-    BAUD_1500000,
-    BAUD_2000000,
-    BAUD_3000000,
-
     BAUD_LOWER = BAUD_2400,
-    BAUD_UPPER = BAUD_3000000
+    BAUD_UPPER = BAUD_14400
   };
 
   // *** Parameter Values ***


### PR DESCRIPTION
Reverts ElTangas/jtag2updi#55

Reverted because on JICE_io.cpp, new baud rates have semicolons terminators instead of commas.